### PR TITLE
Fix ALLOWED_HOSTS fallback handling

### DIFF
--- a/tall_project/settings.py
+++ b/tall_project/settings.py
@@ -10,7 +10,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", "dev-change-me")
 DEBUG = os.getenv("DEBUG", "False") == "True"
 
-_default_allowed = [host.strip() for host in os.getenv("ALLOWED_HOSTS", "*").split(",") if host.strip()]
+_default_allowed = [
+    host.strip() for host in os.getenv("ALLOWED_HOSTS", "").split(",") if host.strip()
+]
 ALLOWED_HOSTS = [
     "numerologist.setaei.com",
     "localhost",


### PR DESCRIPTION
## Summary
- remove the wildcard default from ALLOWED_HOSTS so deployments without an explicit list keep host header protection

## Testing
- python -m compileall intake tall_project

------
https://chatgpt.com/codex/tasks/task_e_68e5b8264ff483239bf4326630934048