### PR TITLE
Add documentation backlog and Numerologens Verden article index template

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Current live subdomain:
 - [API Reference](docs/API_Reference.md)
 - [Architecture Overview](docs/Architecture_Overview.md)
 - [Contributors & Credits](docs/Contributors_and_Credits.md)
+- [Documentation Backlog](docs/Documentation_Backlog.md)
+- [Numerologens Verden – Åse Steinsland Article Index](docs/NumerologensVerden_Articles.md)
 
 ---
 

--- a/docs/Documentation_Backlog.md
+++ b/docs/Documentation_Backlog.md
@@ -1,0 +1,23 @@
+# Documentation Backlog
+
+This checklist tracks documentation that is either missing or requires expansion so the Numerologist project can be shared with collaborators without extra context.
+
+## Completed references
+- [x] [Setup Guide](Setup_Guide.md) – Installation and environment bootstrapping.
+- [x] [Numerology Engine](Numerology_Engine.md) – Core calculations and helper utilities.
+- [x] [Architecture Overview](Architecture_Overview.md) – High-level technical structure.
+- [x] [API Reference](API_Reference.md) – Current endpoints and schemas.
+- [x] [Contributors & Credits](Contributors_and_Credits.md) – Project acknowledgements.
+
+## High-priority gaps
+- [ ] **Intake workflow handbook**: Walkthrough of the practitioner intake app (`intake/`) covering validation, result interpretation, and how to extend explanations in `constants.py`.
+- [ ] **CMS operations guide**: Steps to manage Wagtail pages, configure editorial workflows, and deploy content updates without code changes.
+- [ ] **Deployment runbook**: Environment variables, Passenger/Gunicorn configuration, and backup strategy for numerologist.setaei.com.
+- [ ] **Quality assurance playbook**: Testing approach for numerology calculations, forms, and accessibility checks for templates.
+
+## Research backlog
+- [ ] **Numerologens Verden content map**: Structured index of Åse Steinsland articles (see `NumerologensVerden_Articles.md`).
+- [ ] **Localization guidelines**: Define terminology, tone, and translation process for English, Norwegian, and Persian releases.
+- [ ] **Client workspace product spec**: UX flows for the upcoming workspace modules highlighted on the landing page.
+
+Keep this list updated as new documentation is published or requirements evolve.

--- a/docs/NumerologensVerden_Articles.md
+++ b/docs/NumerologensVerden_Articles.md
@@ -1,0 +1,28 @@
+# Numerologens Verden – Åse Steinsland Article Index
+
+> **Note on data collection**: Direct crawling from `https://www.numerologensverden.no/` is currently blocked in this environment (HTTP 403). Use an offline export or manual review to populate the table below, then commit updates here for long-term reference.
+
+## How to use this index
+1. Visit the article list on Numerologens Verden and capture each post written by Åse Steinsland.
+2. Classify the focus area: famous names, places, time periods, or events. Add additional tags if needed.
+3. Identify the primary numerology number discussed. If multiple numbers are present, list the leading vibration first and separate others with commas.
+4. Copy the canonical URL.
+5. Summarise the core insight in one sentence to help future research.
+
+## Article overview
+
+| Title | Focus Area | Primary Number(s) | URL | Summary |
+|-------|------------|-------------------|-----|---------|
+| _Example: «Navnet Åse – et 3-tall»_ | Famous name | 3 | https://www.numerologensverden.no/eksempel | Short synopsis of Åse&rsquo;s interpretation. |
+| | | | | |
+| | | | | |
+| | | | | |
+| | | | | |
+
+## Tracking completeness
+- [ ] Famous names articles captured
+- [ ] Places articles captured
+- [ ] Time periods articles captured
+- [ ] Events articles captured
+
+Revisit this file whenever new articles go live so the research backlog stays current.


### PR DESCRIPTION
## Summary
- add a documentation backlog checklist that captures missing and in-progress references
- provide a structured template for indexing Åse Steinsland articles from Numerologens Verden
- link the new documentation from the main README for quick discovery

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e70f6678288323852654b451d79481