### PR TITLE
Add roadmap and numerology about pages

### DIFF
--- a/about-academy.html
+++ b/about-academy.html
@@ -1,0 +1,399 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Numerologist Studio — Academy & AI</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --page-bg: #fdf7f0;
+        --card-bg: #ffffff;
+        --card-elevated: #fffaf4;
+        --border: #f0dfcd;
+        --text: #2a2220;
+        --muted: #6f5b53;
+        --accent: #ff8a3d;
+        --accent-soft: rgba(255, 138, 61, 0.12);
+        --accent-strong: #f55d0d;
+        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        color: var(--text);
+        display: flex;
+        flex-direction: column;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      header {
+        padding: 1.5rem 2.5rem 1rem;
+      }
+
+      .nav-shell {
+        max-width: 1080px;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 2rem;
+      }
+
+      .brand {
+        display: grid;
+        gap: 0.1rem;
+      }
+
+      .brand small {
+        font-size: 0.75rem;
+        letter-spacing: 0.3em;
+        font-weight: 600;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+
+      .brand strong {
+        font-size: 1.15rem;
+        font-weight: 700;
+      }
+
+      .nav-links {
+        display: flex;
+        align-items: center;
+        gap: 1.25rem;
+        font-size: 0.95rem;
+      }
+
+      .nav-links a,
+      .nav-links summary {
+        color: var(--muted);
+        font-weight: 600;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        transition: color 0.2s ease;
+      }
+
+      .nav-links summary {
+        list-style: none;
+      }
+
+      .nav-links summary::-webkit-details-marker,
+      .nav-links summary::marker {
+        display: none;
+      }
+
+      .nav-links summary::after {
+        content: "▾";
+        font-size: 0.65rem;
+        transition: transform 0.2s ease;
+      }
+
+      .nav-links details {
+        position: relative;
+      }
+
+      .nav-links details[open] > summary {
+        color: var(--text);
+      }
+
+      .nav-links details[open] > summary::after {
+        transform: rotate(180deg);
+      }
+
+      .nav-dropdown {
+        position: absolute;
+        top: calc(100% + 0.75rem);
+        left: 0;
+        min-width: 14rem;
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 0.75rem;
+        display: grid;
+        gap: 0.35rem;
+        box-shadow: var(--shadow);
+        z-index: 10;
+      }
+
+      .nav-dropdown a {
+        font-weight: 600;
+        color: var(--muted);
+        padding: 0.35rem 0.5rem;
+        border-radius: 10px;
+      }
+
+      .nav-dropdown a:hover,
+      .nav-dropdown a:focus {
+        color: var(--text);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .nav-links summary:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 4px;
+      }
+
+      .mode-toggle {
+        border: 1px solid rgba(0, 0, 0, 0.05);
+        background: #fff;
+        border-radius: 999px;
+        padding: 0.45rem 1.1rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        color: var(--muted);
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease;
+      }
+
+      .mode-toggle:hover {
+        transform: translateY(-1px);
+      }
+
+      main {
+        flex: 1;
+        padding: 0 1.5rem 3.5rem;
+      }
+
+      .layout {
+        max-width: 880px;
+        margin: 0 auto;
+        display: grid;
+        gap: 2.5rem;
+      }
+
+      h1 {
+        font-size: clamp(2.1rem, 4vw, 2.9rem);
+        margin: 0;
+        letter-spacing: -0.02em;
+      }
+
+      h2 {
+        margin: 0 0 0.35rem;
+        font-size: 1.6rem;
+      }
+
+      p {
+        margin: 0 0 1rem;
+        color: var(--muted);
+        line-height: 1.7;
+      }
+
+      .card {
+        background: linear-gradient(150deg, rgba(255, 243, 227, 0.9), rgba(255, 255, 255, 0.95));
+        border-radius: 32px;
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+        box-shadow: var(--shadow);
+        display: grid;
+        gap: 1rem;
+      }
+
+      .module-grid {
+        display: grid;
+        gap: 1.75rem;
+      }
+
+      .module {
+        background: var(--card-bg);
+        border-radius: 28px;
+        border: 1px solid var(--border);
+        padding: clamp(1.35rem, 2.5vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
+      footer {
+        padding: 2rem 1.5rem 3rem;
+        text-align: center;
+        color: var(--muted);
+        font-size: 0.85rem;
+      }
+
+      @media (max-width: 720px) {
+        header {
+          padding: 1.25rem 1.5rem 0.75rem;
+        }
+
+        .nav-shell {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .nav-links {
+          flex-wrap: wrap;
+          gap: 1rem;
+        }
+
+        .nav-dropdown {
+          position: static;
+          width: 100%;
+          box-shadow: none;
+        }
+
+        .module {
+          border-radius: 22px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="nav-shell">
+        <a class="brand" href="/">
+          <small>ÅSE STEINSLAND</small>
+          <strong>Numerologist Studio</strong>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="/intake/">Intake</a>
+          <a href="/cms/">CMS</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <details open>
+            <summary>About Nummerology</summary>
+            <div class="nav-dropdown">
+              <a href="/about.html">Our Story</a>
+              <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+              <a href="/about-academy.html" aria-current="page">Academy &amp; AI</a>
+            </div>
+          </details>
+          <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+            <span aria-hidden="true">🌞</span>
+            Night mode
+          </button>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <div class="layout">
+        <section class="card" aria-labelledby="academy-title">
+          <h1 id="academy-title">Building Numerologist Studio Academy</h1>
+          <p>
+            The academy is our invitation to learn, practise, and teach numerology together. We combine Åse's curriculum with AI-assisted
+            translation, interactive lessons, and live mentorship so that seekers can study in their native language without losing the
+            texture of Åse's storytelling.
+          </p>
+        </section>
+        <section class="module-grid" aria-label="Academy roadmap">
+          <article class="module">
+            <h2>AI-guided translation circles</h2>
+            <p>
+              We pair translators and cultural advisors with language models that draft first-pass translations. Each lesson is reviewed by
+              humans who understand both numerology and the nuances of the target language.
+            </p>
+            <ul>
+              <li>Create shared glossaries that capture Åse's metaphors and preferred tone.</li>
+              <li>Use AI to surface alternative phrasing while humans decide what feels most resonant.</li>
+              <li>Offer pronunciation guides and audio support for names, mantras, and rituals.</li>
+            </ul>
+          </article>
+          <article class="module">
+            <h2>Studio labs &amp; mentorship</h2>
+            <p>
+              Learners can practise readings inside guided sandboxes powered by our Python calculators. Mentors review session logs, annotate
+              insights, and encourage reflection exercises that blend intuition with data.
+            </p>
+            <ul>
+              <li>Spin up calculator sandboxes through GitHub Codespaces for fast experimentation.</li>
+              <li>Use Codex to suggest feedback prompts, while mentors approve and personalise them.</li>
+              <li>Publish community case studies that celebrate diverse reading styles.</li>
+            </ul>
+          </article>
+          <article class="module">
+            <h2>Tjorw API for purposeful futures</h2>
+            <p>
+              The Tjorw calculator API transforms academy learnings into responsible services. We envision it helping career coaches, guidance
+              counsellors, and employers design supportive pathways rather than algorithmic gatekeeping.
+            </p>
+            <ul>
+              <li>Match students with workshops, apprenticeships, and job experiments that fit their numerological profile.</li>
+              <li>Audit API insights for bias, ensuring recommendations expand options instead of narrowing them.</li>
+              <li>Invite graduates to contribute new modules, sustaining a circle of shared employment wisdom.</li>
+            </ul>
+          </article>
+        </section>
+      </div>
+    </main>
+    <footer>© <span id="year"></span> Numerologist Studio. Guided by Åse Steinsland.</footer>
+    <script>
+      const modeToggle = document.getElementById("modeToggle");
+      const setMode = (night) => {
+        document.body.classList.toggle("night", night);
+        modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
+        modeToggle.innerHTML = night
+          ? '<span aria-hidden="true">🌙</span> Light mode'
+          : '<span aria-hidden="true">🌞</span> Night mode';
+        localStorage.setItem("numerologist-mode", night ? "night" : "day");
+      };
+
+      modeToggle.addEventListener("click", () => {
+        setMode(!document.body.classList.contains("night"));
+      });
+
+      const savedMode = localStorage.getItem("numerologist-mode");
+      if (savedMode === "night") {
+        setMode(true);
+      }
+
+      document.getElementById("year").textContent = new Date().getFullYear();
+
+      const nightStyles = document.createElement("style");
+      nightStyles.textContent = `
+        body.night {
+          background: radial-gradient(circle at top right, rgba(69, 48, 107, 0.45), transparent 60%),
+            radial-gradient(circle at bottom left, rgba(255, 138, 61, 0.15), transparent 55%), #1f1b2a;
+          color: #f6f2ff;
+        }
+        body.night .card {
+          background: linear-gradient(150deg, rgba(53, 39, 79, 0.85), rgba(30, 25, 42, 0.95));
+        }
+        body.night .module {
+          background: rgba(33, 28, 46, 0.92);
+          border-color: rgba(115, 90, 168, 0.4);
+        }
+        body.night .nav-links a,
+        body.night .nav-links summary,
+        body.night .mode-toggle {
+          color: rgba(246, 242, 255, 0.75);
+        }
+        body.night .nav-dropdown {
+          background: rgba(30, 25, 42, 0.95);
+          border-color: rgba(115, 90, 168, 0.4);
+          box-shadow: 0px 30px 60px rgba(22, 16, 38, 0.6);
+        }
+        body.night .nav-dropdown a:hover,
+        body.night .nav-dropdown a:focus {
+          background: rgba(255, 138, 61, 0.2);
+          color: #f6f2ff;
+        }
+        body.night .mode-toggle {
+          background: rgba(246, 242, 255, 0.08);
+          border-color: rgba(115, 90, 168, 0.3);
+        }
+      `;
+      document.head.appendChild(nightStyles);
+    </script>
+  </body>
+</html>

--- a/about-vision-mission.html
+++ b/about-vision-mission.html
@@ -1,0 +1,399 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Numerologist Studio — Vision & Mission</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --page-bg: #fdf7f0;
+        --card-bg: #ffffff;
+        --card-elevated: #fffaf4;
+        --border: #f0dfcd;
+        --text: #2a2220;
+        --muted: #6f5b53;
+        --accent: #ff8a3d;
+        --accent-soft: rgba(255, 138, 61, 0.12);
+        --accent-strong: #f55d0d;
+        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        color: var(--text);
+        display: flex;
+        flex-direction: column;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      header {
+        padding: 1.5rem 2.5rem 1rem;
+      }
+
+      .nav-shell {
+        max-width: 1080px;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 2rem;
+      }
+
+      .brand {
+        display: grid;
+        gap: 0.1rem;
+      }
+
+      .brand small {
+        font-size: 0.75rem;
+        letter-spacing: 0.3em;
+        font-weight: 600;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+
+      .brand strong {
+        font-size: 1.15rem;
+        font-weight: 700;
+      }
+
+      .nav-links {
+        display: flex;
+        align-items: center;
+        gap: 1.25rem;
+        font-size: 0.95rem;
+      }
+
+      .nav-links a,
+      .nav-links summary {
+        color: var(--muted);
+        font-weight: 600;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        transition: color 0.2s ease;
+      }
+
+      .nav-links summary {
+        list-style: none;
+      }
+
+      .nav-links summary::-webkit-details-marker,
+      .nav-links summary::marker {
+        display: none;
+      }
+
+      .nav-links summary::after {
+        content: "▾";
+        font-size: 0.65rem;
+        transition: transform 0.2s ease;
+      }
+
+      .nav-links details {
+        position: relative;
+      }
+
+      .nav-links details[open] > summary {
+        color: var(--text);
+      }
+
+      .nav-links details[open] > summary::after {
+        transform: rotate(180deg);
+      }
+
+      .nav-dropdown {
+        position: absolute;
+        top: calc(100% + 0.75rem);
+        left: 0;
+        min-width: 14rem;
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 0.75rem;
+        display: grid;
+        gap: 0.35rem;
+        box-shadow: var(--shadow);
+        z-index: 10;
+      }
+
+      .nav-dropdown a {
+        font-weight: 600;
+        color: var(--muted);
+        padding: 0.35rem 0.5rem;
+        border-radius: 10px;
+      }
+
+      .nav-dropdown a:hover,
+      .nav-dropdown a:focus {
+        color: var(--text);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .nav-links summary:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 4px;
+      }
+
+      .mode-toggle {
+        border: 1px solid rgba(0, 0, 0, 0.05);
+        background: #fff;
+        border-radius: 999px;
+        padding: 0.45rem 1.1rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        color: var(--muted);
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease;
+      }
+
+      .mode-toggle:hover {
+        transform: translateY(-1px);
+      }
+
+      main {
+        flex: 1;
+        padding: 0 1.5rem 3.5rem;
+      }
+
+      .layout {
+        max-width: 860px;
+        margin: 0 auto;
+        display: grid;
+        gap: 2.5rem;
+      }
+
+      h1 {
+        font-size: clamp(2.1rem, 4vw, 2.9rem);
+        margin: 0;
+        letter-spacing: -0.02em;
+      }
+
+      h2 {
+        margin: 0 0 0.35rem;
+        font-size: 1.6rem;
+      }
+
+      p {
+        margin: 0 0 1rem;
+        color: var(--muted);
+        line-height: 1.7;
+      }
+
+      .card {
+        background: linear-gradient(150deg, rgba(255, 243, 227, 0.9), rgba(255, 255, 255, 0.95));
+        border-radius: 32px;
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+        box-shadow: var(--shadow);
+        display: grid;
+        gap: 1rem;
+      }
+
+      .pillar-grid {
+        display: grid;
+        gap: 1.75rem;
+      }
+
+      .pillar {
+        background: var(--card-bg);
+        border-radius: 28px;
+        border: 1px solid var(--border);
+        padding: clamp(1.35rem, 2.5vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
+      footer {
+        padding: 2rem 1.5rem 3rem;
+        text-align: center;
+        color: var(--muted);
+        font-size: 0.85rem;
+      }
+
+      @media (max-width: 720px) {
+        header {
+          padding: 1.25rem 1.5rem 0.75rem;
+        }
+
+        .nav-shell {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .nav-links {
+          flex-wrap: wrap;
+          gap: 1rem;
+        }
+
+        .nav-dropdown {
+          position: static;
+          width: 100%;
+          box-shadow: none;
+        }
+
+        .pillar {
+          border-radius: 22px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="nav-shell">
+        <a class="brand" href="/">
+          <small>ÅSE STEINSLAND</small>
+          <strong>Numerologist Studio</strong>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="/intake/">Intake</a>
+          <a href="/cms/">CMS</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <details open>
+            <summary>About Nummerology</summary>
+            <div class="nav-dropdown">
+              <a href="/about.html">Our Story</a>
+              <a href="/about-vision-mission.html" aria-current="page">Vision &amp; Mission</a>
+              <a href="/about-academy.html">Academy &amp; AI</a>
+            </div>
+          </details>
+          <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+            <span aria-hidden="true">🌞</span>
+            Night mode
+          </button>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <div class="layout">
+        <section class="card" aria-labelledby="vision-title">
+          <h1 id="vision-title">Our vision & mission</h1>
+          <p>
+            We envision a world where numerology is accessible, ethical, and multilingual—where seekers feel supported as they translate
+            numbers into next steps. Numerologist Studio exists to nurture that journey through compassionate technology and a community
+            that honours lived experience.
+          </p>
+        </section>
+        <section class="pillar-grid" aria-label="Vision pillars">
+          <article class="pillar">
+            <h2>Vision</h2>
+            <p>
+              Numerologist Studio is a lighthouse for intuitive learning. We steward Åse's wisdom while embracing new voices, new languages,
+              and new mediums so that every student can find their resonance.
+            </p>
+            <ul>
+              <li>Keep the soul of Åse's practice present in every calculator, course, and ceremony.</li>
+              <li>Offer bilingual and accessible resources that welcome learners across cultures.</li>
+              <li>Model collaborative leadership grounded in care, humour, and accountability.</li>
+            </ul>
+          </article>
+          <article class="pillar">
+            <h2>Mission</h2>
+            <p>
+              Our mission is to make numerology studyable, teachable, and actionable. We document rituals, codify calculators, and invite
+              mentors to co-create guidance that feels personal, practical, and safe.
+            </p>
+            <ul>
+              <li>Transform handwritten notes into transparent playbooks using GitHub and Codex.</li>
+              <li>Co-design curriculum and practice spaces that empower students to become confident readers.</li>
+              <li>Invest in privacy-first tools so seekers can trust the insights they receive.</li>
+            </ul>
+          </article>
+          <article class="pillar">
+            <h2>Technology with tenderness</h2>
+            <p>
+              Technology is here to serve the heart of the work. Codex helps us refactor code with care, while Python keeps each calculator
+              reliable, secure, and fast enough for live sessions. We measure success by how gracefully the tools support real people.
+            </p>
+            <ul>
+              <li>Pair human review with AI-assisted translations to preserve nuance.</li>
+              <li>Use open pull requests and rituals of gratitude to celebrate contributions.</li>
+              <li>Release privacy checklists and inclusive language guides alongside new features.</li>
+            </ul>
+          </article>
+        </section>
+      </div>
+    </main>
+    <footer>© <span id="year"></span> Numerologist Studio. Guided by Åse Steinsland.</footer>
+    <script>
+      const modeToggle = document.getElementById("modeToggle");
+      const setMode = (night) => {
+        document.body.classList.toggle("night", night);
+        modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
+        modeToggle.innerHTML = night
+          ? '<span aria-hidden="true">🌙</span> Light mode'
+          : '<span aria-hidden="true">🌞</span> Night mode';
+        localStorage.setItem("numerologist-mode", night ? "night" : "day");
+      };
+
+      modeToggle.addEventListener("click", () => {
+        setMode(!document.body.classList.contains("night"));
+      });
+
+      const savedMode = localStorage.getItem("numerologist-mode");
+      if (savedMode === "night") {
+        setMode(true);
+      }
+
+      document.getElementById("year").textContent = new Date().getFullYear();
+
+      const nightStyles = document.createElement("style");
+      nightStyles.textContent = `
+        body.night {
+          background: radial-gradient(circle at top right, rgba(69, 48, 107, 0.45), transparent 60%),
+            radial-gradient(circle at bottom left, rgba(255, 138, 61, 0.15), transparent 55%), #1f1b2a;
+          color: #f6f2ff;
+        }
+        body.night .card {
+          background: linear-gradient(150deg, rgba(53, 39, 79, 0.85), rgba(30, 25, 42, 0.95));
+        }
+        body.night .pillar {
+          background: rgba(33, 28, 46, 0.92);
+          border-color: rgba(115, 90, 168, 0.4);
+        }
+        body.night .nav-links a,
+        body.night .nav-links summary,
+        body.night .mode-toggle {
+          color: rgba(246, 242, 255, 0.75);
+        }
+        body.night .nav-dropdown {
+          background: rgba(30, 25, 42, 0.95);
+          border-color: rgba(115, 90, 168, 0.4);
+          box-shadow: 0px 30px 60px rgba(22, 16, 38, 0.6);
+        }
+        body.night .nav-dropdown a:hover,
+        body.night .nav-dropdown a:focus {
+          background: rgba(255, 138, 61, 0.2);
+          color: #f6f2ff;
+        }
+        body.night .mode-toggle {
+          background: rgba(246, 242, 255, 0.08);
+          border-color: rgba(115, 90, 168, 0.3);
+        }
+      `;
+      document.head.appendChild(nightStyles);
+    </script>
+  </body>
+</html>

--- a/about.html
+++ b/about.html
@@ -1,0 +1,391 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Numerologist Studio — Our Story</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --page-bg: #fdf7f0;
+        --card-bg: #ffffff;
+        --card-elevated: #fffaf4;
+        --border: #f0dfcd;
+        --text: #2a2220;
+        --muted: #6f5b53;
+        --accent: #ff8a3d;
+        --accent-soft: rgba(255, 138, 61, 0.12);
+        --accent-strong: #f55d0d;
+        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        color: var(--text);
+        display: flex;
+        flex-direction: column;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      header {
+        padding: 1.5rem 2.5rem 1rem;
+      }
+
+      .nav-shell {
+        max-width: 1080px;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 2rem;
+      }
+
+      .brand {
+        display: grid;
+        gap: 0.1rem;
+      }
+
+      .brand small {
+        font-size: 0.75rem;
+        letter-spacing: 0.3em;
+        font-weight: 600;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+
+      .brand strong {
+        font-size: 1.15rem;
+        font-weight: 700;
+      }
+
+      .nav-links {
+        display: flex;
+        align-items: center;
+        gap: 1.25rem;
+        font-size: 0.95rem;
+      }
+
+      .nav-links a,
+      .nav-links summary {
+        color: var(--muted);
+        font-weight: 600;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        transition: color 0.2s ease;
+      }
+
+      .nav-links summary {
+        list-style: none;
+      }
+
+      .nav-links summary::-webkit-details-marker,
+      .nav-links summary::marker {
+        display: none;
+      }
+
+      .nav-links summary::after {
+        content: "▾";
+        font-size: 0.65rem;
+        transition: transform 0.2s ease;
+      }
+
+      .nav-links details {
+        position: relative;
+      }
+
+      .nav-links details[open] > summary {
+        color: var(--text);
+      }
+
+      .nav-links details[open] > summary::after {
+        transform: rotate(180deg);
+      }
+
+      .nav-dropdown {
+        position: absolute;
+        top: calc(100% + 0.75rem);
+        left: 0;
+        min-width: 14rem;
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 0.75rem;
+        display: grid;
+        gap: 0.35rem;
+        box-shadow: var(--shadow);
+        z-index: 10;
+      }
+
+      .nav-dropdown a {
+        font-weight: 600;
+        color: var(--muted);
+        padding: 0.35rem 0.5rem;
+        border-radius: 10px;
+      }
+
+      .nav-dropdown a:hover,
+      .nav-dropdown a:focus {
+        color: var(--text);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .nav-links summary:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 4px;
+      }
+
+      .mode-toggle {
+        border: 1px solid rgba(0, 0, 0, 0.05);
+        background: #fff;
+        border-radius: 999px;
+        padding: 0.45rem 1.1rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        color: var(--muted);
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease;
+      }
+
+      .mode-toggle:hover {
+        transform: translateY(-1px);
+      }
+
+      main {
+        flex: 1;
+        padding: 0 1.5rem 3.5rem;
+      }
+
+      .layout {
+        max-width: 860px;
+        margin: 0 auto;
+        display: grid;
+        gap: 2.5rem;
+      }
+
+      h1 {
+        font-size: clamp(2.1rem, 4vw, 2.9rem);
+        margin: 0;
+        letter-spacing: -0.02em;
+      }
+
+      h2 {
+        margin: 0 0 0.35rem;
+        font-size: 1.6rem;
+      }
+
+      p {
+        margin: 0 0 1rem;
+        color: var(--muted);
+        line-height: 1.7;
+      }
+
+      .card {
+        background: linear-gradient(150deg, rgba(255, 243, 227, 0.9), rgba(255, 255, 255, 0.95));
+        border-radius: 32px;
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+        box-shadow: var(--shadow);
+        display: grid;
+        gap: 1rem;
+      }
+
+      .story-grid {
+        display: grid;
+        gap: 1.75rem;
+      }
+
+      .story-card {
+        background: var(--card-bg);
+        border-radius: 28px;
+        border: 1px solid var(--border);
+        padding: clamp(1.35rem, 2.5vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      blockquote {
+        margin: 0;
+        padding-left: 1.1rem;
+        border-left: 3px solid var(--accent);
+        color: var(--muted);
+        font-style: italic;
+      }
+
+      footer {
+        padding: 2rem 1.5rem 3rem;
+        text-align: center;
+        color: var(--muted);
+        font-size: 0.85rem;
+      }
+
+      @media (max-width: 720px) {
+        header {
+          padding: 1.25rem 1.5rem 0.75rem;
+        }
+
+        .nav-shell {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .nav-links {
+          flex-wrap: wrap;
+          gap: 1rem;
+        }
+
+        .nav-dropdown {
+          position: static;
+          width: 100%;
+          box-shadow: none;
+        }
+
+        .story-card {
+          border-radius: 22px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="nav-shell">
+        <a class="brand" href="/">
+          <small>ÅSE STEINSLAND</small>
+          <strong>Numerologist Studio</strong>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="/intake/">Intake</a>
+          <a href="/cms/">CMS</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <details open>
+            <summary aria-current="page">About Nummerology</summary>
+            <div class="nav-dropdown">
+              <a href="/about.html" aria-current="page">Our Story</a>
+              <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+              <a href="/about-academy.html">Academy &amp; AI</a>
+            </div>
+          </details>
+          <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+            <span aria-hidden="true">🌞</span>
+            Night mode
+          </button>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <div class="layout">
+        <section class="card" aria-labelledby="about-title">
+          <h1 id="about-title">Åse's story, woven into Numerologist Studio</h1>
+          <p>
+            What began as Åse Steinsland's intimate numerology readings has grown into a studio for seekers, students, and mentors.
+            Every calculator, meditation, and journal prompt is grounded in Åse's decades of practice and her belief that numbers can
+            soften life's sharp edges.
+          </p>
+          <p>
+            Numerologist Studio keeps that heart-forward approach. We document rituals with the same warmth Åse brings to her sessions,
+            inviting contributors to honour the quiet details—pronunciation of a name, the stories held in a birthdate, the way guidance
+            lands differently for every soul.
+          </p>
+        </section>
+        <section class="story-grid" aria-label="Studio values">
+          <article class="story-card">
+            <h2>Rooted in relationship</h2>
+            <p>
+              We favour deep listening over dashboards. Contributors are encouraged to sit with Åse's language, observe how she introduces
+              each calculator, and echo that care within the tools we build. The studio is a gathering space, not just a tech project.
+            </p>
+            <blockquote>“Numerology is the art of being present with someone's story long enough for the numbers to speak.”</blockquote>
+          </article>
+          <article class="story-card">
+            <h2>Crafted for guidance</h2>
+            <p>
+              From intake forms to follow-up rituals, every element is designed as a gentle guide. We map learning journeys that blend
+              practical numerology with reflection, so the studio supports both professional readers and curious newcomers.
+            </p>
+          </article>
+          <article class="story-card">
+            <h2>Powered by community</h2>
+            <p>
+              Developers, translators, and mentors collaborate in the open. GitHub keeps our work transparent; Codex helps transform Åse's
+              notes into polished experiences. Together we steward her legacy while making space for new voices.
+            </p>
+          </article>
+        </section>
+      </div>
+    </main>
+    <footer>© <span id="year"></span> Numerologist Studio. Guided by Åse Steinsland.</footer>
+    <script>
+      const modeToggle = document.getElementById("modeToggle");
+      const setMode = (night) => {
+        document.body.classList.toggle("night", night);
+        modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
+        modeToggle.innerHTML = night
+          ? '<span aria-hidden="true">🌙</span> Light mode'
+          : '<span aria-hidden="true">🌞</span> Night mode';
+        localStorage.setItem("numerologist-mode", night ? "night" : "day");
+      };
+
+      modeToggle.addEventListener("click", () => {
+        setMode(!document.body.classList.contains("night"));
+      });
+
+      const savedMode = localStorage.getItem("numerologist-mode");
+      if (savedMode === "night") {
+        setMode(true);
+      }
+
+      document.getElementById("year").textContent = new Date().getFullYear();
+
+      const nightStyles = document.createElement("style");
+      nightStyles.textContent = `
+        body.night {
+          background: radial-gradient(circle at top right, rgba(69, 48, 107, 0.45), transparent 60%),
+            radial-gradient(circle at bottom left, rgba(255, 138, 61, 0.15), transparent 55%), #1f1b2a;
+          color: #f6f2ff;
+        }
+        body.night .card {
+          background: linear-gradient(150deg, rgba(53, 39, 79, 0.85), rgba(30, 25, 42, 0.95));
+        }
+        body.night .story-card {
+          background: rgba(33, 28, 46, 0.92);
+          border-color: rgba(115, 90, 168, 0.4);
+        }
+        body.night .nav-links a,
+        body.night .nav-links summary,
+        body.night .mode-toggle {
+          color: rgba(246, 242, 255, 0.75);
+        }
+        body.night .nav-dropdown {
+          background: rgba(30, 25, 42, 0.95);
+          border-color: rgba(115, 90, 168, 0.4);
+          box-shadow: 0px 30px 60px rgba(22, 16, 38, 0.6);
+        }
+        body.night .nav-dropdown a:hover,
+        body.night .nav-dropdown a:focus {
+          background: rgba(255, 138, 61, 0.2);
+          color: #f6f2ff;
+        }
+        body.night .mode-toggle {
+          background: rgba(246, 242, 255, 0.08);
+          border-color: rgba(115, 90, 168, 0.3);
+        }
+      `;
+      document.head.appendChild(nightStyles);
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -77,9 +77,76 @@
         font-size: 0.95rem;
       }
 
-      .nav-links a {
+      .nav-links a,
+      .nav-links summary {
         color: var(--muted);
         font-weight: 600;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        transition: color 0.2s ease;
+      }
+
+      .nav-links summary {
+        list-style: none;
+      }
+
+      .nav-links summary::-webkit-details-marker,
+      .nav-links summary::marker {
+        display: none;
+      }
+
+      .nav-links summary::after {
+        content: "▾";
+        font-size: 0.65rem;
+        transition: transform 0.2s ease;
+      }
+
+      .nav-links details {
+        position: relative;
+      }
+
+      .nav-links details[open] > summary {
+        color: var(--text);
+      }
+
+      .nav-links details[open] > summary::after {
+        transform: rotate(180deg);
+      }
+
+      .nav-dropdown {
+        position: absolute;
+        top: calc(100% + 0.75rem);
+        left: 0;
+        min-width: 14rem;
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 0.75rem;
+        display: grid;
+        gap: 0.35rem;
+        box-shadow: var(--shadow);
+        z-index: 10;
+      }
+
+      .nav-dropdown a {
+        font-weight: 600;
+        color: var(--muted);
+        padding: 0.35rem 0.5rem;
+        border-radius: 10px;
+      }
+
+      .nav-dropdown a:hover,
+      .nav-dropdown a:focus {
+        color: var(--text);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .nav-links summary:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 4px;
       }
 
       .mode-toggle {
@@ -396,6 +463,23 @@
           padding: 1.25rem 1.25rem 0.5rem;
         }
 
+        .nav-shell {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 1rem;
+        }
+
+        .nav-links {
+          flex-wrap: wrap;
+          gap: 1rem;
+        }
+
+        .nav-dropdown {
+          position: static;
+          width: 100%;
+          box-shadow: none;
+        }
+
         main {
           padding: 0 1rem 2.5rem;
         }
@@ -420,14 +504,23 @@
           <small>ÅSE STEINSLAND</small>
           <strong>Numerologist Studio</strong>
         </a>
-        <div class="nav-links">
+        <nav class="nav-links" aria-label="Primary">
           <a href="/intake/">Intake</a>
           <a href="/cms/">CMS</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <details>
+            <summary>About Nummerology</summary>
+            <div class="nav-dropdown">
+              <a href="/about.html">Our Story</a>
+              <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+              <a href="/about-academy.html">Academy &amp; AI</a>
+            </div>
+          </details>
           <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
             <span aria-hidden="true">🌞</span>
             Night mode
           </button>
-        </div>
+        </nav>
       </div>
     </header>
     <main>
@@ -807,8 +900,19 @@
           color: rgba(246, 242, 255, 0.65);
         }
         body.night .nav-links a,
+        body.night .nav-links summary,
         body.night .mode-toggle {
           color: rgba(246, 242, 255, 0.75);
+        }
+        body.night .nav-dropdown {
+          background: rgba(30, 25, 42, 0.95);
+          border-color: rgba(115, 90, 168, 0.4);
+          box-shadow: 0px 30px 60px rgba(22, 16, 38, 0.6);
+        }
+        body.night .nav-dropdown a:hover,
+        body.night .nav-dropdown a:focus {
+          background: rgba(255, 138, 61, 0.2);
+          color: #f6f2ff;
         }
         body.night .mode-toggle {
           background: rgba(246, 242, 255, 0.08);

--- a/roadmap.html
+++ b/roadmap.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Numerologist Studio — Roadmap</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --page-bg: #fdf7f0;
+        --card-bg: #ffffff;
+        --card-elevated: #fffaf4;
+        --border: #f0dfcd;
+        --text: #2a2220;
+        --muted: #6f5b53;
+        --accent: #ff8a3d;
+        --accent-soft: rgba(255, 138, 61, 0.12);
+        --accent-strong: #f55d0d;
+        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        color: var(--text);
+        display: flex;
+        flex-direction: column;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      header {
+        padding: 1.5rem 2.5rem 1rem;
+      }
+
+      .nav-shell {
+        max-width: 1080px;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 2rem;
+      }
+
+      .brand {
+        display: grid;
+        gap: 0.1rem;
+      }
+
+      .brand small {
+        font-size: 0.75rem;
+        letter-spacing: 0.3em;
+        font-weight: 600;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+
+      .brand strong {
+        font-size: 1.15rem;
+        font-weight: 700;
+      }
+
+      .nav-links {
+        display: flex;
+        align-items: center;
+        gap: 1.25rem;
+        font-size: 0.95rem;
+      }
+
+      .nav-links a,
+      .nav-links summary {
+        color: var(--muted);
+        font-weight: 600;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        transition: color 0.2s ease;
+      }
+
+      .nav-links summary {
+        list-style: none;
+      }
+
+      .nav-links summary::-webkit-details-marker,
+      .nav-links summary::marker {
+        display: none;
+      }
+
+      .nav-links summary::after {
+        content: "▾";
+        font-size: 0.65rem;
+        transition: transform 0.2s ease;
+      }
+
+      .nav-links details {
+        position: relative;
+      }
+
+      .nav-links details[open] > summary {
+        color: var(--text);
+      }
+
+      .nav-links details[open] > summary::after {
+        transform: rotate(180deg);
+      }
+
+      .nav-dropdown {
+        position: absolute;
+        top: calc(100% + 0.75rem);
+        left: 0;
+        min-width: 14rem;
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 0.75rem;
+        display: grid;
+        gap: 0.35rem;
+        box-shadow: var(--shadow);
+        z-index: 10;
+      }
+
+      .nav-dropdown a {
+        font-weight: 600;
+        color: var(--muted);
+        padding: 0.35rem 0.5rem;
+        border-radius: 10px;
+      }
+
+      .nav-dropdown a:hover,
+      .nav-dropdown a:focus {
+        color: var(--text);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .nav-links summary:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 4px;
+      }
+
+      .mode-toggle {
+        border: 1px solid rgba(0, 0, 0, 0.05);
+        background: #fff;
+        border-radius: 999px;
+        padding: 0.45rem 1.1rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        color: var(--muted);
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease;
+      }
+
+      .mode-toggle:hover {
+        transform: translateY(-1px);
+      }
+
+      main {
+        flex: 1;
+        padding: 0 1.5rem 3.5rem;
+      }
+
+      .layout {
+        max-width: 880px;
+        margin: 0 auto;
+        display: grid;
+        gap: 2.5rem;
+      }
+
+      h1 {
+        font-size: clamp(2.1rem, 4vw, 2.9rem);
+        margin: 0;
+        letter-spacing: -0.02em;
+      }
+
+      h2 {
+        margin: 0 0 0.35rem;
+        font-size: 1.6rem;
+      }
+
+      p {
+        margin: 0 0 1rem;
+        color: var(--muted);
+        line-height: 1.65;
+      }
+
+      .card {
+        background: linear-gradient(150deg, rgba(255, 243, 227, 0.9), rgba(255, 255, 255, 0.95));
+        border-radius: 32px;
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+        box-shadow: var(--shadow);
+        display: grid;
+        gap: 1rem;
+      }
+
+      .phase-list {
+        display: grid;
+        gap: 1.75rem;
+      }
+
+      .phase {
+        background: var(--card-bg);
+        border-radius: 28px;
+        border: 1px solid var(--border);
+        padding: clamp(1.35rem, 2.5vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .phase strong {
+        font-size: 1.1rem;
+        color: var(--text);
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
+      footer {
+        padding: 2rem 1.5rem 3rem;
+        text-align: center;
+        color: var(--muted);
+        font-size: 0.85rem;
+      }
+
+      @media (max-width: 720px) {
+        header {
+          padding: 1.25rem 1.5rem 0.75rem;
+        }
+
+        .nav-shell {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .nav-links {
+          flex-wrap: wrap;
+          gap: 1rem;
+        }
+
+        .nav-dropdown {
+          position: static;
+          width: 100%;
+          box-shadow: none;
+        }
+
+        .phase {
+          border-radius: 22px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="nav-shell">
+        <a class="brand" href="/">
+          <small>ÅSE STEINSLAND</small>
+          <strong>Numerologist Studio</strong>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="/intake/">Intake</a>
+          <a href="/cms/">CMS</a>
+          <a href="/roadmap.html" aria-current="page">Roadmap</a>
+          <details>
+            <summary>About Nummerology</summary>
+            <div class="nav-dropdown">
+              <a href="/about.html">Our Story</a>
+              <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+              <a href="/about-academy.html">Academy &amp; AI</a>
+            </div>
+          </details>
+          <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+            <span aria-hidden="true">🌞</span>
+            Night mode
+          </button>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <div class="layout">
+        <section class="card" aria-labelledby="roadmap-title">
+          <h1 id="roadmap-title">Our evolving roadmap</h1>
+          <p>
+            Numerologist Studio is growing from Åse's intimate readings into a living, collaborative academy. Below you'll find the
+            strategic phases guiding how we blend numerological wisdom with modern craft—keeping everything warm, human, and ready for
+            learners worldwide.
+          </p>
+        </section>
+        <section class="phase-list" aria-label="Roadmap phases">
+          <article class="phase">
+            <strong>Phase 1 · Foundations of trust</strong>
+            <p>
+              We are curating Åse's library of calculators, stories, and rituals into a shared GitHub home. GitHub Copilot and Codex help
+              us translate her intuition into clear documentation, reusable Python notebooks, and calm interfaces so every contributor can
+              move with confidence.
+            </p>
+            <ul>
+              <li>Document the original reading flow and glossary of Åse's language.</li>
+              <li>Stitch Codex suggestions into pull requests so that new features stay true to her voice.</li>
+              <li>Publish community guidelines that keep privacy, empathy, and spiritual consent at the centre.</li>
+            </ul>
+          </article>
+          <article class="phase">
+            <strong>Phase 2 · Python as our fast &amp; secure builder</strong>
+            <p>
+              Python powers every calculator behind the studio. We're hardening those tools with automated tests, typed data models, and
+              secure packaging so readings scale safely. Codex reviews GitHub actions to keep deployments quick, auditable, and ready for
+              mentors joining from anywhere.
+            </p>
+            <ul>
+              <li>Refactor each calculator into shareable Python packages with clear APIs.</li>
+              <li>Adopt security scanning and dependency reviews to protect student data.</li>
+              <li>Create lightning-fast sandboxes so mentors can prototype spreads in minutes.</li>
+            </ul>
+          </article>
+          <article class="phase">
+            <strong>Phase 3 · Global translation &amp; academy launch</strong>
+            <p>
+              AI translation lets Åse's teachings arrive in the language students dream in. We pair linguistic models with Åse's edits to
+              keep nuance, while an interactive learning portal introduces Numerologist Studio Academy. Learners explore lessons, practice
+              rituals, and earn badges that reflect both numerological progress and personal growth.
+            </p>
+            <ul>
+              <li>Co-create course storyboards with bilingual mentors and AI-assisted drafts.</li>
+              <li>Launch live workshops with instant translation, captioning, and glossary syncing.</li>
+              <li>Open an application path for apprenticeships and community-led cohorts.</li>
+            </ul>
+          </article>
+          <article class="phase">
+            <strong>Phase 4 · Tjorw calculator API &amp; future work</strong>
+            <p>
+              The Tjorw calculator API transforms years of numerology practice into a transparent service. By offering ethical automation,
+              we help career seekers, HR teams, and spiritual entrepreneurs design pathways that honour numerological insights without
+              replacing human wisdom.
+            </p>
+            <ul>
+              <li>Provide secure API keys with role-based access for partners and job-matching innovators.</li>
+              <li>Blend numerological profiles with coaching prompts that uplift job hunters rather than filter them out.</li>
+              <li>Publish open dashboards that show how Tjorw recommendations stay bias-aware and supportive.</li>
+            </ul>
+          </article>
+        </section>
+      </div>
+    </main>
+    <footer>© <span id="year"></span> Numerologist Studio. Guided by Åse Steinsland.</footer>
+    <script>
+      const modeToggle = document.getElementById("modeToggle");
+      const setMode = (night) => {
+        document.body.classList.toggle("night", night);
+        modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
+        modeToggle.innerHTML = night
+          ? '<span aria-hidden="true">🌙</span> Light mode'
+          : '<span aria-hidden="true">🌞</span> Night mode';
+        localStorage.setItem("numerologist-mode", night ? "night" : "day");
+      };
+
+      modeToggle.addEventListener("click", () => {
+        setMode(!document.body.classList.contains("night"));
+      });
+
+      const savedMode = localStorage.getItem("numerologist-mode");
+      if (savedMode === "night") {
+        setMode(true);
+      }
+
+      document.getElementById("year").textContent = new Date().getFullYear();
+
+      const nightStyles = document.createElement("style");
+      nightStyles.textContent = `
+        body.night {
+          background: radial-gradient(circle at top right, rgba(69, 48, 107, 0.45), transparent 60%),
+            radial-gradient(circle at bottom left, rgba(255, 138, 61, 0.15), transparent 55%), #1f1b2a;
+          color: #f6f2ff;
+        }
+        body.night .card {
+          background: linear-gradient(150deg, rgba(53, 39, 79, 0.85), rgba(30, 25, 42, 0.95));
+        }
+        body.night .phase {
+          background: rgba(33, 28, 46, 0.92);
+          border-color: rgba(115, 90, 168, 0.4);
+        }
+        body.night .nav-links a,
+        body.night .nav-links summary,
+        body.night .mode-toggle {
+          color: rgba(246, 242, 255, 0.75);
+        }
+        body.night .nav-dropdown {
+          background: rgba(30, 25, 42, 0.95);
+          border-color: rgba(115, 90, 168, 0.4);
+          box-shadow: 0px 30px 60px rgba(22, 16, 38, 0.6);
+        }
+        body.night .nav-dropdown a:hover,
+        body.night .nav-dropdown a:focus {
+          background: rgba(255, 138, 61, 0.2);
+          color: #f6f2ff;
+        }
+        body.night .mode-toggle {
+          background: rgba(246, 242, 255, 0.08);
+          border-color: rgba(115, 90, 168, 0.3);
+        }
+      `;
+      document.head.appendChild(nightStyles);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a roadmap page outlining Codex, Python, translation, and Tjorw API initiatives for Numerologist Studio
- introduce dedicated about pages for our story, vision and mission, and the academy with AI support
- enhance the landing page navigation with a Roadmap link and an About Nummerology dropdown that works in light and night modes

## Testing
- Not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e719d8f8388323a76c5f8de168fafc