### PR TITLE
Fix intake form tests to run under Django test runner

### DIFF
--- a/intake/tests/test_forms.py
+++ b/intake/tests/test_forms.py
@@ -1,21 +1,39 @@
-from datetime import date
+from django.test import SimpleTestCase
 
 from intake.forms import IntakeForm
 
 
-def test_numerology_profile_core_numbers():
-    form = IntakeForm(
-        data={
-            "full_name": "Ada Lovelace",
-            "email": "ada@example.com",
-            "birth_date": date(1815, 12, 10),
-        }
-    )
-    assert form.is_valid(), form.errors
-    profile = form.numerology_profile().as_dict()
-    assert profile["life_path"] == 1
-    assert profile["birth_day"] == 1
-    assert profile["expression"] == 3
-    assert profile["soul_urge"] == 6
-    assert profile["personality"] == 6
-    assert profile["maturity"] == 4
+class IntakeFormTests(SimpleTestCase):
+    def test_numerology_profile_core_numbers(self) -> None:
+        """The numerology profile should return the expected core numbers."""
+
+        form = IntakeForm(
+            data={
+                "full_name": "Ada Lovelace",
+                "email": "ada@example.com",
+                # ``DateField`` expects an ISO formatted string when binding form data.
+                "birth_date": "1815-12-10",
+            }
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        profile = form.numerology_profile().as_dict()
+
+        self.assertEqual(profile["life_path"], 1)
+        self.assertEqual(profile["birth_day"], 1)
+        self.assertEqual(profile["expression"], 9)
+        self.assertEqual(profile["soul_urge"], 1)
+        self.assertEqual(profile["personality"], 8)
+        self.assertEqual(profile["maturity"], 1)
+
+    def test_clean_full_name_normalizes_whitespace(self) -> None:
+        form = IntakeForm(
+            data={
+                "full_name": "  Ada   Byron   Lovelace  ",
+                "email": "ada@example.com",
+                "birth_date": "1815-12-10",
+            }
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["full_name"], "Ada Byron Lovelace")


### PR DESCRIPTION
## Summary
- convert the intake form tests to use Django's SimpleTestCase for proper discovery
- update expected numerology values to match the implemented calculations
- add coverage for whitespace normalization in the full name cleaning logic

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68e8257210808323af753da4b4b0be67