### PR TITLE
Add Norwegian locale and refresh footer language controls

### DIFF
--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -13,6 +13,26 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
+#: tall_project/settings.py:127
+msgid "English"
+msgstr "انگلیسی"
+
+#: tall_project/settings.py:128
+msgid "Norwegian Bokmål"
+msgstr "نروژی بوکمول"
+
+#: tall_project/settings.py:129
+msgid "Persian"
+msgstr "فارسی"
+
+#: tall_project/templates/base.html:233
+msgid "Switch language"
+msgstr "تغییر زبان"
+
+#: tall_project/templates/base.html:262
+msgid "Developed in collaboration with numerologist Åse Steinsland using her calculation method — implemented with Python, Codex, and Git."
+msgstr "توسعه‌یافته با همکاری علم اعداد آسه استینسلاند با بهره‌گیری از روش محاسباتی او — پیاده‌سازی‌شده با پایتون، کودکس و گیت."
+
 #: tall_project/navigation.py:32 tall_project/navigation.py:103
 msgid "Discover Numerology"
 msgstr "کشف علم اعداد"

--- a/locale/nb/LC_MESSAGES/django.po
+++ b/locale/nb/LC_MESSAGES/django.po
@@ -1,0 +1,38 @@
+# Norwegian Bokmål translations for Numerologist
+msgid ""
+msgstr ""
+"Project-Id-Version: Numerologist\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-10-09 03:13+0000\n"
+"PO-Revision-Date: 2025-10-09 00:00+0000\n"
+"Last-Translator: ChatGPT <>\n"
+"Language-Team: Norwegian Bokmål\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: tall_project/settings.py:127
+msgid "English"
+msgstr "Engelsk"
+
+#: tall_project/settings.py:128
+msgid "Norwegian Bokmål"
+msgstr "Norsk bokmål"
+
+#: tall_project/settings.py:129
+msgid "Persian"
+msgstr "Persisk"
+
+#: tall_project/templates/base.html:233
+msgid "Switch language"
+msgstr "Bytt språk"
+
+#: tall_project/templates/base.html:262
+msgid "Developed in collaboration with numerologist Åse Steinsland using her calculation method — implemented with Python, Codex, and Git."
+msgstr "Utviklet i samarbeid med numerolog Åse Steinsland ved hjelp av hennes kalkulasjonsmetode – implementert med Python, Codex og Git."
+
+#: tall_project/templates/base.html:263
+msgid "All rights reserved."
+msgstr "Alle rettigheter reservert."

--- a/tall_project/settings.py
+++ b/tall_project/settings.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 from urllib.parse import urlparse
 
+from django.utils.translation import gettext_lazy as _
+
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", "dev-change-me")
@@ -122,8 +124,9 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en"
 LANGUAGES = [
-    ("en", "English"),
-    ("fa", "Persian"),
+    ("en", _("English")),
+    ("nb", _("Norwegian Bokmål")),
+    ("fa", _("Persian")),
 ]
 LOCALE_PATHS = [BASE_DIR / "locale"]
 TIME_ZONE = "UTC"

--- a/tall_project/templates/base.html
+++ b/tall_project/templates/base.html
@@ -105,31 +105,46 @@
         align-items: center;
         gap: 1rem;
       }
-      .language-switcher {
+      .language-toggle {
         display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        font-size: 0.95rem;
-      }
-      .language-switcher select,
-      .language-switcher button {
+        align-items: stretch;
         border: 1px solid var(--border);
-        background: var(--surface);
-        color: inherit;
-        padding: 0.35rem 0.75rem;
-      }
-      .language-switcher button {
-        cursor: pointer;
         border-radius: 999px;
+        background: var(--surface);
+        overflow: hidden;
+        font-size: 0.9rem;
       }
-      .language-switcher select {
-        border-radius: 0.5rem;
+      .language-toggle form {
+        margin: 0;
+        display: flex;
+      }
+      .language-toggle button {
+        appearance: none;
+        border: none;
+        background: transparent;
+        color: inherit;
+        padding: 0.4rem 0.85rem;
+        cursor: pointer;
+        font-weight: 600;
+        transition: background 0.2s ease, color 0.2s ease;
+      }
+      .language-toggle form + form button {
+        border-inline-start: 1px solid var(--border);
+      }
+      .language-toggle button:is(:focus-visible, :hover) {
+        background: rgba(90, 49, 244, 0.12);
+      }
+      .language-toggle button.is-active {
+        background: var(--accent);
+        color: #fff;
       }
       main {
         flex: 1;
         padding: 2.5rem 0 3rem;
       }
-      footer p {
+      footer .footer-copy {
+        display: grid;
+        gap: 0.25rem;
         margin: 0;
         font-size: 0.9rem;
         text-align: center;
@@ -219,21 +234,24 @@
               <li><a href="/cms/" rel="noreferrer" target="_blank">{% trans "CMS" %}</a></li>
             </ul>
           </nav>
-          <form class="language-switcher" action="{% url 'set_language' %}" method="post">
-            {% csrf_token %}
-            <label for="language-select">{% trans "Language" %}</label>
-            <select id="language-select" name="language">
-              {% get_available_languages as languages %}
-              {% get_language_info_list for languages as languages_info %}
-              {% for language in languages_info %}
-                <option value="{{ language.code }}" {% if language.code == CURRENT_LANGUAGE %}selected{% endif %}>
-                  {{ language.name_local }}
-                </option>
-              {% endfor %}
-            </select>
-            <input type="hidden" name="next" value="{{ request.get_full_path }}" />
-            <button type="submit">{% trans "Apply" %}</button>
-          </form>
+          <div class="language-toggle" role="group" aria-label="{% trans 'Switch language' %}">
+            {% get_available_languages as languages %}
+            {% get_language_info_list for languages as languages_info %}
+            {% for language in languages_info %}
+              <form action="{% url 'set_language' %}" method="post">
+                {% csrf_token %}
+                <input type="hidden" name="language" value="{{ language.code }}" />
+                <input type="hidden" name="next" value="{{ request.get_full_path }}" />
+                <button
+                  type="submit"
+                  class="language-toggle__btn{% if language.code == CURRENT_LANGUAGE %} is-active{% endif %}"
+                  {% if language.code == CURRENT_LANGUAGE %}aria-pressed="true"{% endif %}
+                >
+                  {{ language.code|upper }}
+                </button>
+              </form>
+            {% endfor %}
+          </div>
         </div>
       </div>
     </header>
@@ -244,7 +262,10 @@
     </main>
     <footer>
       <div class="container">
-        <p>&copy; {% now "Y" %} Numerologist. {% trans "All rights reserved." %}</p>
+        <p class="footer-copy">
+          &copy; {% now "Y" %} Setaei Intelligence. {% trans "Developed in collaboration with numerologist Åse Steinsland using her calculation method — implemented with Python, Codex, and Git." %}
+          <span>{% trans "All rights reserved." %}</span>
+        </p>
       </div>
     </footer>
   </body>


### PR DESCRIPTION
## Summary
- replace the header language dropdown with a segmented toggle and update the footer copy
- register Norwegian Bokmål support in settings and expose lazy labels for the language list
- add Norwegian translations and extend the Persian catalog for the new interface strings

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e82efffd148323b71c28d0ece14951