### PR TITLE
Add Dockerfile for Django project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        build-essential \
+        libpq-dev \
+        default-libmysqlclient-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+
+RUN python -m venv /venv \
+    && . /venv/bin/activate \
+    && pip install --upgrade pip \
+    && pip install -r requirements.txt
+
+ENV PATH="/venv/bin:$PATH"
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
## Summary
- add a Dockerfile using the python:3.11-slim base image
- install system libraries needed for PostgreSQL and MySQL clients and Pillow
- install project dependencies and run the Django development server by default

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fb5c04b52c8323ac8650b9ff1f14c0