### PR TITLE
feat: refresh navigation with green burger menu

### DIFF
--- a/about-academy.html
+++ b/about-academy.html
@@ -7,16 +7,16 @@
     <style>
       :root {
         color-scheme: light;
-        --page-bg: #fdf7f0;
+        --page-bg: #f0f8f3;
         --card-bg: #ffffff;
-        --card-elevated: #fffaf4;
-        --border: #f0dfcd;
-        --text: #2a2220;
-        --muted: #6f5b53;
-        --accent: #ff8a3d;
-        --accent-soft: rgba(255, 138, 61, 0.12);
-        --accent-strong: #f55d0d;
-        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        --card-elevated: #f7fcf8;
+        --border: #c8e5d2;
+        --text: #1f3327;
+        --muted: #4f6b59;
+        --accent: #3cb179;
+        --accent-soft: rgba(60, 177, 121, 0.12);
+        --accent-strong: #2d8f60;
+        --shadow: 0px 30px 60px rgba(92, 170, 120, 0.28);
         font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
       }
 
@@ -27,8 +27,8 @@
       body {
         margin: 0;
         min-height: 100vh;
-        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
-          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        background: radial-gradient(circle at top right, rgba(94, 214, 149, 0.32), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(72, 176, 120, 0.2), transparent 55%), var(--page-bg);
         color: var(--text);
         display: flex;
         flex-direction: column;
@@ -70,11 +70,93 @@
         font-weight: 700;
       }
 
-      .nav-links {
-        display: flex;
+      .menu-toggle {
+        border: none;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        display: inline-flex;
         align-items: center;
-        gap: 1.25rem;
+        gap: 0.65rem;
         font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+      }
+
+      .menu-toggle:hover,
+      .menu-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-strong);
+        outline: none;
+      }
+
+      .menu-icon {
+        position: relative;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: background 0.2s ease;
+      }
+
+      .menu-icon::before,
+      .menu-icon::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: transform 0.2s ease;
+      }
+
+      .menu-icon::before {
+        top: -6px;
+      }
+
+      .menu-icon::after {
+        top: 6px;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon {
+        background: transparent;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::before {
+        transform: translateY(6px) rotate(45deg);
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::after {
+        transform: translateY(-6px) rotate(-45deg);
+      }
+
+      .menu-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .nav-links {
+        position: fixed;
+        inset: 0 0 0 auto;
+        width: min(320px, 85vw);
+        background: var(--card-bg);
+        border-left: 1px solid var(--border);
+        box-shadow: -24px 0 60px rgba(17, 37, 23, 0.18);
+        padding: 6rem 1.75rem 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 20;
+      }
+
+      body.menu-open .nav-links {
+        transform: translateX(0);
       }
 
       .nav-links a,
@@ -82,10 +164,13 @@
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        display: inline-flex;
+        display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: 0.35rem;
-        transition: color 0.2s ease;
+        padding: 0.75rem 1rem;
+        border-radius: 14px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-links summary {
@@ -97,18 +182,18 @@
         display: none;
       }
 
+      .nav-links details {
+        width: 100%;
+      }
+
       .nav-links summary::after {
         content: "▾";
-        font-size: 0.65rem;
+        font-size: 0.75rem;
         transition: transform 0.2s ease;
       }
 
-      .nav-links details {
-        position: relative;
-      }
-
       .nav-links details[open] > summary {
-        color: var(--text);
+        color: var(--accent-strong);
       }
 
       .nav-links details[open] > summary::after {
@@ -116,30 +201,27 @@
       }
 
       .nav-dropdown {
-        position: absolute;
-        top: calc(100% + 0.75rem);
-        left: 0;
-        min-width: 14rem;
+        margin-top: 0.35rem;
         background: var(--card-bg);
         border: 1px solid var(--border);
-        border-radius: 16px;
-        padding: 0.75rem;
+        border-radius: 14px;
+        padding: 0.5rem;
         display: grid;
         gap: 0.35rem;
-        box-shadow: var(--shadow);
-        z-index: 10;
+        box-shadow: none;
       }
 
       .nav-dropdown a {
         font-weight: 600;
         color: var(--muted);
-        padding: 0.35rem 0.5rem;
+        padding: 0.45rem 0.75rem;
         border-radius: 10px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-dropdown a:hover,
-      .nav-dropdown a:focus {
-        color: var(--text);
+      .nav-dropdown a:focus-visible {
+        color: var(--accent-strong);
         background: var(--accent-soft);
         outline: none;
       }
@@ -150,21 +232,44 @@
       }
 
       .mode-toggle {
-        border: 1px solid rgba(0, 0, 0, 0.05);
+        border: 1px solid rgba(60, 177, 121, 0.3);
         background: #fff;
         border-radius: 999px;
-        padding: 0.45rem 1.1rem;
+        padding: 0.6rem 1.1rem;
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        transition: transform 0.2s ease;
+        transition: transform 0.2s ease, background 0.2s ease;
+        justify-content: center;
       }
 
-      .mode-toggle:hover {
+      .mode-toggle:hover,
+      .mode-toggle:focus-visible {
         transform: translateY(-1px);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .menu-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 35, 23, 0.4);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 10;
+      }
+
+      body.menu-open .menu-overlay {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      body.menu-open {
+        overflow: hidden;
       }
 
       main {
@@ -197,7 +302,7 @@
       }
 
       .card {
-        background: linear-gradient(150deg, rgba(255, 243, 227, 0.9), rgba(255, 255, 255, 0.95));
+        background: linear-gradient(150deg, rgba(214, 244, 227, 0.9), rgba(255, 255, 255, 0.95));
         border-radius: 32px;
         padding: clamp(1.75rem, 3vw, 2.5rem);
         box-shadow: var(--shadow);
@@ -267,28 +372,33 @@
           <small>ÅSE STEINSLAND</small>
           <strong>Numerologist Studio</strong>
         </a>
-        <nav class="nav-links" aria-label="Primary">
-          <a href="/intake/">Intake</a>
-          <a href="/cms/">CMS</a>
-          <a href="/roadmap.html">Roadmap</a>
-          <a href="/calculators.html">Calculators</a>
-          <a href="/arecibo.html">Arecibo Line</a>
-          <a href="/articles.html">Articles</a>
-          <details open>
-            <summary>About Nummerology</summary>
-            <div class="nav-dropdown">
-              <a href="/about.html">Our Story</a>
-              <a href="/about-vision-mission.html">Vision &amp; Mission</a>
-              <a href="/about-academy.html" aria-current="page">Academy &amp; AI</a>
-            </div>
-          </details>
-          <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
-            <span aria-hidden="true">🌞</span>
-            Night mode
-          </button>
-        </nav>
+        <button class="menu-toggle" type="button" id="menuToggle" aria-expanded="false" aria-controls="primaryNav">
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label">Menu</span>
+        </button>
       </div>
+      <nav class="nav-links" id="primaryNav" aria-label="Primary" aria-hidden="true">
+        <a href="/intake/">Intake</a>
+        <a href="/cms/">CMS</a>
+        <a href="/roadmap.html">Roadmap</a>
+        <a href="/calculators.html">Calculators</a>
+        <a href="/arecibo.html">Arecibo Line</a>
+        <a href="/articles.html">Articles</a>
+        <details>
+          <summary>About Nummerology</summary>
+          <div class="nav-dropdown">
+            <a href="/about.html">Our Story</a>
+            <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+            <a href="/about-academy.html">Academy &amp; AI</a>
+          </div>
+        </details>
+        <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+          <span aria-hidden="true">🌞</span>
+          Night mode
+        </button>
+      </nav>
     </header>
+    <div class="menu-overlay" id="menuOverlay" hidden></div>
     <main>
       <div class="layout">
         <section class="card" aria-labelledby="academy-title">
@@ -342,6 +452,61 @@
     <footer>© <span id="year"></span> Numerologist Studio. Guided by Åse Steinsland.</footer>
     <script>
       const modeToggle = document.getElementById("modeToggle");
+      const menuToggleButton = document.getElementById("menuToggle");
+      const primaryNav = document.getElementById("primaryNav");
+      const menuOverlay = document.getElementById("menuOverlay");
+
+      const setMenuState = (open) => {
+        if (menuToggleButton) {
+          menuToggleButton.setAttribute("aria-expanded", String(open));
+        }
+        if (primaryNav) {
+          primaryNav.setAttribute("aria-hidden", String(!open));
+        }
+        if (menuOverlay) {
+          if (open) {
+            menuOverlay.removeAttribute("hidden");
+          } else {
+            menuOverlay.setAttribute("hidden", "");
+          }
+        }
+        document.body.classList.toggle("menu-open", open);
+      };
+
+      const closeMenu = () => {
+        setMenuState(false);
+        primaryNav?.querySelectorAll("details[open]").forEach((detail) => {
+          detail.removeAttribute("open");
+        });
+      };
+      const openMenu = () => setMenuState(true);
+
+      menuToggleButton?.addEventListener("click", () => {
+        const expanded = menuToggleButton.getAttribute("aria-expanded") === "true";
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      menuOverlay?.addEventListener("click", closeMenu);
+
+      primaryNav?.querySelectorAll("a").forEach((link) => {
+        link.addEventListener("click", closeMenu);
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          const expanded = menuToggleButton?.getAttribute("aria-expanded") === "true";
+          if (expanded) {
+            closeMenu();
+            menuToggleButton?.focus();
+          }
+        }
+      });
+
+
       const setMode = (night) => {
         document.body.classList.toggle("night", night);
         modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
@@ -352,6 +517,7 @@
       };
 
       modeToggle.addEventListener("click", () => {
+        closeMenu();
         setMode(!document.body.classList.contains("night"));
       });
 
@@ -365,35 +531,76 @@
       const nightStyles = document.createElement("style");
       nightStyles.textContent = `
         body.night {
-          background: radial-gradient(circle at top right, rgba(69, 48, 107, 0.45), transparent 60%),
-            radial-gradient(circle at bottom left, rgba(255, 138, 61, 0.15), transparent 55%), #1f1b2a;
-          color: #f6f2ff;
+          background: #0e1713;
+          color: #e8f5ec;
         }
-        body.night .card {
-          background: linear-gradient(150deg, rgba(53, 39, 79, 0.85), rgba(30, 25, 42, 0.95));
+        body.night header,
+        body.night main {
+          background: transparent;
         }
-        body.night .module {
-          background: rgba(33, 28, 46, 0.92);
-          border-color: rgba(115, 90, 168, 0.4);
+        body.night .hero-card,
+        body.night .step-card,
+        body.night .snapshot-card,
+        body.night .stories-card {
+          background: #13231b;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
+        }
+        body.night .progress-footer {
+          background: rgba(10, 20, 15, 0.92);
+          border-top-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .progress-card {
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.3);
+          box-shadow: none;
+        }
+        body.night .progress-track {
+          background: rgba(60, 177, 121, 0.2);
+        }
+        body.night .progress-bar {
+          background: linear-gradient(135deg, #3cb179, #67f0aa);
+          box-shadow: 0 10px 25px rgba(60, 177, 121, 0.35);
+        }
+        body.night .snapshot-tile,
+        body.night .story-tile {
+          background: rgba(60, 177, 121, 0.18);
+          border-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .pill {
+          background: rgba(60, 177, 121, 0.2);
+          color: rgba(232, 245, 236, 0.85);
+          border-color: rgba(60, 177, 121, 0.35);
+        }
+        body.night .nav-links {
+          background: #0f1d17;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: -24px 0 60px rgba(0, 0, 0, 0.55);
         }
         body.night .nav-links a,
         body.night .nav-links summary,
         body.night .mode-toggle {
-          color: rgba(246, 242, 255, 0.75);
+          color: rgba(232, 245, 236, 0.78);
         }
         body.night .nav-dropdown {
-          background: rgba(30, 25, 42, 0.95);
-          border-color: rgba(115, 90, 168, 0.4);
-          box-shadow: 0px 30px 60px rgba(22, 16, 38, 0.6);
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
         }
         body.night .nav-dropdown a:hover,
         body.night .nav-dropdown a:focus {
-          background: rgba(255, 138, 61, 0.2);
-          color: #f6f2ff;
+          background: rgba(60, 177, 121, 0.22);
+          color: #e8f5ec;
         }
         body.night .mode-toggle {
-          background: rgba(246, 242, 255, 0.08);
-          border-color: rgba(115, 90, 168, 0.3);
+          background: rgba(60, 177, 121, 0.16);
+          border-color: rgba(60, 177, 121, 0.3);
+        }
+        body.night .menu-overlay {
+          background: rgba(4, 12, 8, 0.7);
+        }
+        body.night footer {
+          color: rgba(232, 245, 236, 0.7);
         }
       `;
       document.head.appendChild(nightStyles);

--- a/about-vision-mission.html
+++ b/about-vision-mission.html
@@ -7,16 +7,16 @@
     <style>
       :root {
         color-scheme: light;
-        --page-bg: #fdf7f0;
+        --page-bg: #f0f8f3;
         --card-bg: #ffffff;
-        --card-elevated: #fffaf4;
-        --border: #f0dfcd;
-        --text: #2a2220;
-        --muted: #6f5b53;
-        --accent: #ff8a3d;
-        --accent-soft: rgba(255, 138, 61, 0.12);
-        --accent-strong: #f55d0d;
-        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        --card-elevated: #f7fcf8;
+        --border: #c8e5d2;
+        --text: #1f3327;
+        --muted: #4f6b59;
+        --accent: #3cb179;
+        --accent-soft: rgba(60, 177, 121, 0.12);
+        --accent-strong: #2d8f60;
+        --shadow: 0px 30px 60px rgba(92, 170, 120, 0.28);
         font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
       }
 
@@ -27,8 +27,8 @@
       body {
         margin: 0;
         min-height: 100vh;
-        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
-          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        background: radial-gradient(circle at top right, rgba(94, 214, 149, 0.32), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(72, 176, 120, 0.2), transparent 55%), var(--page-bg);
         color: var(--text);
         display: flex;
         flex-direction: column;
@@ -70,11 +70,93 @@
         font-weight: 700;
       }
 
-      .nav-links {
-        display: flex;
+      .menu-toggle {
+        border: none;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        display: inline-flex;
         align-items: center;
-        gap: 1.25rem;
+        gap: 0.65rem;
         font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+      }
+
+      .menu-toggle:hover,
+      .menu-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-strong);
+        outline: none;
+      }
+
+      .menu-icon {
+        position: relative;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: background 0.2s ease;
+      }
+
+      .menu-icon::before,
+      .menu-icon::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: transform 0.2s ease;
+      }
+
+      .menu-icon::before {
+        top: -6px;
+      }
+
+      .menu-icon::after {
+        top: 6px;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon {
+        background: transparent;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::before {
+        transform: translateY(6px) rotate(45deg);
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::after {
+        transform: translateY(-6px) rotate(-45deg);
+      }
+
+      .menu-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .nav-links {
+        position: fixed;
+        inset: 0 0 0 auto;
+        width: min(320px, 85vw);
+        background: var(--card-bg);
+        border-left: 1px solid var(--border);
+        box-shadow: -24px 0 60px rgba(17, 37, 23, 0.18);
+        padding: 6rem 1.75rem 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 20;
+      }
+
+      body.menu-open .nav-links {
+        transform: translateX(0);
       }
 
       .nav-links a,
@@ -82,10 +164,13 @@
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        display: inline-flex;
+        display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: 0.35rem;
-        transition: color 0.2s ease;
+        padding: 0.75rem 1rem;
+        border-radius: 14px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-links summary {
@@ -97,18 +182,18 @@
         display: none;
       }
 
+      .nav-links details {
+        width: 100%;
+      }
+
       .nav-links summary::after {
         content: "▾";
-        font-size: 0.65rem;
+        font-size: 0.75rem;
         transition: transform 0.2s ease;
       }
 
-      .nav-links details {
-        position: relative;
-      }
-
       .nav-links details[open] > summary {
-        color: var(--text);
+        color: var(--accent-strong);
       }
 
       .nav-links details[open] > summary::after {
@@ -116,30 +201,27 @@
       }
 
       .nav-dropdown {
-        position: absolute;
-        top: calc(100% + 0.75rem);
-        left: 0;
-        min-width: 14rem;
+        margin-top: 0.35rem;
         background: var(--card-bg);
         border: 1px solid var(--border);
-        border-radius: 16px;
-        padding: 0.75rem;
+        border-radius: 14px;
+        padding: 0.5rem;
         display: grid;
         gap: 0.35rem;
-        box-shadow: var(--shadow);
-        z-index: 10;
+        box-shadow: none;
       }
 
       .nav-dropdown a {
         font-weight: 600;
         color: var(--muted);
-        padding: 0.35rem 0.5rem;
+        padding: 0.45rem 0.75rem;
         border-radius: 10px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-dropdown a:hover,
-      .nav-dropdown a:focus {
-        color: var(--text);
+      .nav-dropdown a:focus-visible {
+        color: var(--accent-strong);
         background: var(--accent-soft);
         outline: none;
       }
@@ -150,21 +232,44 @@
       }
 
       .mode-toggle {
-        border: 1px solid rgba(0, 0, 0, 0.05);
+        border: 1px solid rgba(60, 177, 121, 0.3);
         background: #fff;
         border-radius: 999px;
-        padding: 0.45rem 1.1rem;
+        padding: 0.6rem 1.1rem;
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        transition: transform 0.2s ease;
+        transition: transform 0.2s ease, background 0.2s ease;
+        justify-content: center;
       }
 
-      .mode-toggle:hover {
+      .mode-toggle:hover,
+      .mode-toggle:focus-visible {
         transform: translateY(-1px);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .menu-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 35, 23, 0.4);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 10;
+      }
+
+      body.menu-open .menu-overlay {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      body.menu-open {
+        overflow: hidden;
       }
 
       main {
@@ -197,7 +302,7 @@
       }
 
       .card {
-        background: linear-gradient(150deg, rgba(255, 243, 227, 0.9), rgba(255, 255, 255, 0.95));
+        background: linear-gradient(150deg, rgba(214, 244, 227, 0.9), rgba(255, 255, 255, 0.95));
         border-radius: 32px;
         padding: clamp(1.75rem, 3vw, 2.5rem);
         box-shadow: var(--shadow);
@@ -267,28 +372,33 @@
           <small>ÅSE STEINSLAND</small>
           <strong>Numerologist Studio</strong>
         </a>
-        <nav class="nav-links" aria-label="Primary">
-          <a href="/intake/">Intake</a>
-          <a href="/cms/">CMS</a>
-          <a href="/roadmap.html">Roadmap</a>
-          <a href="/calculators.html">Calculators</a>
-          <a href="/arecibo.html">Arecibo Line</a>
-          <a href="/articles.html">Articles</a>
-          <details open>
-            <summary>About Nummerology</summary>
-            <div class="nav-dropdown">
-              <a href="/about.html">Our Story</a>
-              <a href="/about-vision-mission.html" aria-current="page">Vision &amp; Mission</a>
-              <a href="/about-academy.html">Academy &amp; AI</a>
-            </div>
-          </details>
-          <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
-            <span aria-hidden="true">🌞</span>
-            Night mode
-          </button>
-        </nav>
+        <button class="menu-toggle" type="button" id="menuToggle" aria-expanded="false" aria-controls="primaryNav">
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label">Menu</span>
+        </button>
       </div>
+      <nav class="nav-links" id="primaryNav" aria-label="Primary" aria-hidden="true">
+        <a href="/intake/">Intake</a>
+        <a href="/cms/">CMS</a>
+        <a href="/roadmap.html">Roadmap</a>
+        <a href="/calculators.html">Calculators</a>
+        <a href="/arecibo.html">Arecibo Line</a>
+        <a href="/articles.html">Articles</a>
+        <details>
+          <summary>About Nummerology</summary>
+          <div class="nav-dropdown">
+            <a href="/about.html">Our Story</a>
+            <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+            <a href="/about-academy.html">Academy &amp; AI</a>
+          </div>
+        </details>
+        <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+          <span aria-hidden="true">🌞</span>
+          Night mode
+        </button>
+      </nav>
     </header>
+    <div class="menu-overlay" id="menuOverlay" hidden></div>
     <main>
       <div class="layout">
         <section class="card" aria-labelledby="vision-title">
@@ -342,6 +452,61 @@
     <footer>© <span id="year"></span> Numerologist Studio. Guided by Åse Steinsland.</footer>
     <script>
       const modeToggle = document.getElementById("modeToggle");
+      const menuToggleButton = document.getElementById("menuToggle");
+      const primaryNav = document.getElementById("primaryNav");
+      const menuOverlay = document.getElementById("menuOverlay");
+
+      const setMenuState = (open) => {
+        if (menuToggleButton) {
+          menuToggleButton.setAttribute("aria-expanded", String(open));
+        }
+        if (primaryNav) {
+          primaryNav.setAttribute("aria-hidden", String(!open));
+        }
+        if (menuOverlay) {
+          if (open) {
+            menuOverlay.removeAttribute("hidden");
+          } else {
+            menuOverlay.setAttribute("hidden", "");
+          }
+        }
+        document.body.classList.toggle("menu-open", open);
+      };
+
+      const closeMenu = () => {
+        setMenuState(false);
+        primaryNav?.querySelectorAll("details[open]").forEach((detail) => {
+          detail.removeAttribute("open");
+        });
+      };
+      const openMenu = () => setMenuState(true);
+
+      menuToggleButton?.addEventListener("click", () => {
+        const expanded = menuToggleButton.getAttribute("aria-expanded") === "true";
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      menuOverlay?.addEventListener("click", closeMenu);
+
+      primaryNav?.querySelectorAll("a").forEach((link) => {
+        link.addEventListener("click", closeMenu);
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          const expanded = menuToggleButton?.getAttribute("aria-expanded") === "true";
+          if (expanded) {
+            closeMenu();
+            menuToggleButton?.focus();
+          }
+        }
+      });
+
+
       const setMode = (night) => {
         document.body.classList.toggle("night", night);
         modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
@@ -352,6 +517,7 @@
       };
 
       modeToggle.addEventListener("click", () => {
+        closeMenu();
         setMode(!document.body.classList.contains("night"));
       });
 
@@ -365,35 +531,76 @@
       const nightStyles = document.createElement("style");
       nightStyles.textContent = `
         body.night {
-          background: radial-gradient(circle at top right, rgba(69, 48, 107, 0.45), transparent 60%),
-            radial-gradient(circle at bottom left, rgba(255, 138, 61, 0.15), transparent 55%), #1f1b2a;
-          color: #f6f2ff;
+          background: #0e1713;
+          color: #e8f5ec;
         }
-        body.night .card {
-          background: linear-gradient(150deg, rgba(53, 39, 79, 0.85), rgba(30, 25, 42, 0.95));
+        body.night header,
+        body.night main {
+          background: transparent;
         }
-        body.night .pillar {
-          background: rgba(33, 28, 46, 0.92);
-          border-color: rgba(115, 90, 168, 0.4);
+        body.night .hero-card,
+        body.night .step-card,
+        body.night .snapshot-card,
+        body.night .stories-card {
+          background: #13231b;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
+        }
+        body.night .progress-footer {
+          background: rgba(10, 20, 15, 0.92);
+          border-top-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .progress-card {
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.3);
+          box-shadow: none;
+        }
+        body.night .progress-track {
+          background: rgba(60, 177, 121, 0.2);
+        }
+        body.night .progress-bar {
+          background: linear-gradient(135deg, #3cb179, #67f0aa);
+          box-shadow: 0 10px 25px rgba(60, 177, 121, 0.35);
+        }
+        body.night .snapshot-tile,
+        body.night .story-tile {
+          background: rgba(60, 177, 121, 0.18);
+          border-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .pill {
+          background: rgba(60, 177, 121, 0.2);
+          color: rgba(232, 245, 236, 0.85);
+          border-color: rgba(60, 177, 121, 0.35);
+        }
+        body.night .nav-links {
+          background: #0f1d17;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: -24px 0 60px rgba(0, 0, 0, 0.55);
         }
         body.night .nav-links a,
         body.night .nav-links summary,
         body.night .mode-toggle {
-          color: rgba(246, 242, 255, 0.75);
+          color: rgba(232, 245, 236, 0.78);
         }
         body.night .nav-dropdown {
-          background: rgba(30, 25, 42, 0.95);
-          border-color: rgba(115, 90, 168, 0.4);
-          box-shadow: 0px 30px 60px rgba(22, 16, 38, 0.6);
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
         }
         body.night .nav-dropdown a:hover,
         body.night .nav-dropdown a:focus {
-          background: rgba(255, 138, 61, 0.2);
-          color: #f6f2ff;
+          background: rgba(60, 177, 121, 0.22);
+          color: #e8f5ec;
         }
         body.night .mode-toggle {
-          background: rgba(246, 242, 255, 0.08);
-          border-color: rgba(115, 90, 168, 0.3);
+          background: rgba(60, 177, 121, 0.16);
+          border-color: rgba(60, 177, 121, 0.3);
+        }
+        body.night .menu-overlay {
+          background: rgba(4, 12, 8, 0.7);
+        }
+        body.night footer {
+          color: rgba(232, 245, 236, 0.7);
         }
       `;
       document.head.appendChild(nightStyles);

--- a/about.html
+++ b/about.html
@@ -7,16 +7,16 @@
     <style>
       :root {
         color-scheme: light;
-        --page-bg: #fdf7f0;
+        --page-bg: #f0f8f3;
         --card-bg: #ffffff;
-        --card-elevated: #fffaf4;
-        --border: #f0dfcd;
-        --text: #2a2220;
-        --muted: #6f5b53;
-        --accent: #ff8a3d;
-        --accent-soft: rgba(255, 138, 61, 0.12);
-        --accent-strong: #f55d0d;
-        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        --card-elevated: #f7fcf8;
+        --border: #c8e5d2;
+        --text: #1f3327;
+        --muted: #4f6b59;
+        --accent: #3cb179;
+        --accent-soft: rgba(60, 177, 121, 0.12);
+        --accent-strong: #2d8f60;
+        --shadow: 0px 30px 60px rgba(92, 170, 120, 0.28);
         font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
       }
 
@@ -27,8 +27,8 @@
       body {
         margin: 0;
         min-height: 100vh;
-        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
-          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        background: radial-gradient(circle at top right, rgba(94, 214, 149, 0.32), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(72, 176, 120, 0.2), transparent 55%), var(--page-bg);
         color: var(--text);
         display: flex;
         flex-direction: column;
@@ -70,11 +70,93 @@
         font-weight: 700;
       }
 
-      .nav-links {
-        display: flex;
+      .menu-toggle {
+        border: none;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        display: inline-flex;
         align-items: center;
-        gap: 1.25rem;
+        gap: 0.65rem;
         font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+      }
+
+      .menu-toggle:hover,
+      .menu-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-strong);
+        outline: none;
+      }
+
+      .menu-icon {
+        position: relative;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: background 0.2s ease;
+      }
+
+      .menu-icon::before,
+      .menu-icon::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: transform 0.2s ease;
+      }
+
+      .menu-icon::before {
+        top: -6px;
+      }
+
+      .menu-icon::after {
+        top: 6px;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon {
+        background: transparent;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::before {
+        transform: translateY(6px) rotate(45deg);
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::after {
+        transform: translateY(-6px) rotate(-45deg);
+      }
+
+      .menu-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .nav-links {
+        position: fixed;
+        inset: 0 0 0 auto;
+        width: min(320px, 85vw);
+        background: var(--card-bg);
+        border-left: 1px solid var(--border);
+        box-shadow: -24px 0 60px rgba(17, 37, 23, 0.18);
+        padding: 6rem 1.75rem 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 20;
+      }
+
+      body.menu-open .nav-links {
+        transform: translateX(0);
       }
 
       .nav-links a,
@@ -82,10 +164,13 @@
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        display: inline-flex;
+        display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: 0.35rem;
-        transition: color 0.2s ease;
+        padding: 0.75rem 1rem;
+        border-radius: 14px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-links summary {
@@ -97,18 +182,18 @@
         display: none;
       }
 
+      .nav-links details {
+        width: 100%;
+      }
+
       .nav-links summary::after {
         content: "▾";
-        font-size: 0.65rem;
+        font-size: 0.75rem;
         transition: transform 0.2s ease;
       }
 
-      .nav-links details {
-        position: relative;
-      }
-
       .nav-links details[open] > summary {
-        color: var(--text);
+        color: var(--accent-strong);
       }
 
       .nav-links details[open] > summary::after {
@@ -116,30 +201,27 @@
       }
 
       .nav-dropdown {
-        position: absolute;
-        top: calc(100% + 0.75rem);
-        left: 0;
-        min-width: 14rem;
+        margin-top: 0.35rem;
         background: var(--card-bg);
         border: 1px solid var(--border);
-        border-radius: 16px;
-        padding: 0.75rem;
+        border-radius: 14px;
+        padding: 0.5rem;
         display: grid;
         gap: 0.35rem;
-        box-shadow: var(--shadow);
-        z-index: 10;
+        box-shadow: none;
       }
 
       .nav-dropdown a {
         font-weight: 600;
         color: var(--muted);
-        padding: 0.35rem 0.5rem;
+        padding: 0.45rem 0.75rem;
         border-radius: 10px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-dropdown a:hover,
-      .nav-dropdown a:focus {
-        color: var(--text);
+      .nav-dropdown a:focus-visible {
+        color: var(--accent-strong);
         background: var(--accent-soft);
         outline: none;
       }
@@ -150,21 +232,44 @@
       }
 
       .mode-toggle {
-        border: 1px solid rgba(0, 0, 0, 0.05);
+        border: 1px solid rgba(60, 177, 121, 0.3);
         background: #fff;
         border-radius: 999px;
-        padding: 0.45rem 1.1rem;
+        padding: 0.6rem 1.1rem;
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        transition: transform 0.2s ease;
+        transition: transform 0.2s ease, background 0.2s ease;
+        justify-content: center;
       }
 
-      .mode-toggle:hover {
+      .mode-toggle:hover,
+      .mode-toggle:focus-visible {
         transform: translateY(-1px);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .menu-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 35, 23, 0.4);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 10;
+      }
+
+      body.menu-open .menu-overlay {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      body.menu-open {
+        overflow: hidden;
       }
 
       main {
@@ -197,7 +302,7 @@
       }
 
       .card {
-        background: linear-gradient(150deg, rgba(255, 243, 227, 0.9), rgba(255, 255, 255, 0.95));
+        background: linear-gradient(150deg, rgba(214, 244, 227, 0.9), rgba(255, 255, 255, 0.95));
         border-radius: 32px;
         padding: clamp(1.75rem, 3vw, 2.5rem);
         box-shadow: var(--shadow);
@@ -237,15 +342,9 @@
 
       @media (max-width: 900px) {
         .nav-shell {
-          flex-direction: column;
-          align-items: flex-start;
           gap: 1rem;
         }
 
-        .nav-links {
-          flex-wrap: wrap;
-          gap: 1rem;
-        }
       }
 
       @media (max-width: 720px) {
@@ -264,19 +363,6 @@
         }
       }
 
-      @media (max-width: 480px) {
-        .nav-links {
-          flex-direction: column;
-          align-items: flex-start;
-          width: 100%;
-        }
-
-        .nav-links a,
-        .nav-links summary,
-        .mode-toggle {
-          width: 100%;
-        }
-      }
     </style>
   </head>
   <body>
@@ -286,28 +372,33 @@
           <small>ÅSE STEINSLAND</small>
           <strong>Numerologist Studio</strong>
         </a>
-        <nav class="nav-links" aria-label="Primary">
-          <a href="/intake/">Intake</a>
-          <a href="/cms/">CMS</a>
-          <a href="/roadmap.html">Roadmap</a>
-          <a href="/calculators.html">Calculators</a>
-          <a href="/arecibo.html">Arecibo Line</a>
-          <a href="/articles.html">Articles</a>
-          <details open>
-            <summary aria-current="page">About Nummerology</summary>
-            <div class="nav-dropdown">
-              <a href="/about.html" aria-current="page">Our Story</a>
-              <a href="/about-vision-mission.html">Vision &amp; Mission</a>
-              <a href="/about-academy.html">Academy &amp; AI</a>
-            </div>
-          </details>
-          <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
-            <span aria-hidden="true">🌞</span>
-            Night mode
-          </button>
-        </nav>
+        <button class="menu-toggle" type="button" id="menuToggle" aria-expanded="false" aria-controls="primaryNav">
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label">Menu</span>
+        </button>
       </div>
+      <nav class="nav-links" id="primaryNav" aria-label="Primary" aria-hidden="true">
+        <a href="/intake/">Intake</a>
+        <a href="/cms/">CMS</a>
+        <a href="/roadmap.html">Roadmap</a>
+        <a href="/calculators.html">Calculators</a>
+        <a href="/arecibo.html">Arecibo Line</a>
+        <a href="/articles.html">Articles</a>
+        <details>
+          <summary>About Nummerology</summary>
+          <div class="nav-dropdown">
+            <a href="/about.html">Our Story</a>
+            <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+            <a href="/about-academy.html">Academy &amp; AI</a>
+          </div>
+        </details>
+        <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+          <span aria-hidden="true">🌞</span>
+          Night mode
+        </button>
+      </nav>
     </header>
+    <div class="menu-overlay" id="menuOverlay" hidden></div>
     <main>
       <div class="layout">
         <section class="card" aria-labelledby="about-title">
@@ -387,6 +478,61 @@
     <footer>© <span id="year"></span> Numerologist Studio. Guided by Åse Steinsland.</footer>
     <script>
       const modeToggle = document.getElementById("modeToggle");
+      const menuToggleButton = document.getElementById("menuToggle");
+      const primaryNav = document.getElementById("primaryNav");
+      const menuOverlay = document.getElementById("menuOverlay");
+
+      const setMenuState = (open) => {
+        if (menuToggleButton) {
+          menuToggleButton.setAttribute("aria-expanded", String(open));
+        }
+        if (primaryNav) {
+          primaryNav.setAttribute("aria-hidden", String(!open));
+        }
+        if (menuOverlay) {
+          if (open) {
+            menuOverlay.removeAttribute("hidden");
+          } else {
+            menuOverlay.setAttribute("hidden", "");
+          }
+        }
+        document.body.classList.toggle("menu-open", open);
+      };
+
+      const closeMenu = () => {
+        setMenuState(false);
+        primaryNav?.querySelectorAll("details[open]").forEach((detail) => {
+          detail.removeAttribute("open");
+        });
+      };
+      const openMenu = () => setMenuState(true);
+
+      menuToggleButton?.addEventListener("click", () => {
+        const expanded = menuToggleButton.getAttribute("aria-expanded") === "true";
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      menuOverlay?.addEventListener("click", closeMenu);
+
+      primaryNav?.querySelectorAll("a").forEach((link) => {
+        link.addEventListener("click", closeMenu);
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          const expanded = menuToggleButton?.getAttribute("aria-expanded") === "true";
+          if (expanded) {
+            closeMenu();
+            menuToggleButton?.focus();
+          }
+        }
+      });
+
+
       const setMode = (night) => {
         document.body.classList.toggle("night", night);
         modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
@@ -397,6 +543,7 @@
       };
 
       modeToggle.addEventListener("click", () => {
+        closeMenu();
         setMode(!document.body.classList.contains("night"));
       });
 
@@ -410,36 +557,76 @@
       const nightStyles = document.createElement("style");
       nightStyles.textContent = `
         body.night {
-          background: #101322;
-          color: #f4f6ff;
+          background: #0e1713;
+          color: #e8f5ec;
         }
-        body.night .card,
-        body.night .story-card {
-          background: #171b2b;
-          border-color: rgba(92, 105, 210, 0.25);
+        body.night header,
+        body.night main {
+          background: transparent;
+        }
+        body.night .hero-card,
+        body.night .step-card,
+        body.night .snapshot-card,
+        body.night .stories-card {
+          background: #13231b;
+          border-color: rgba(60, 177, 121, 0.25);
           box-shadow: none;
+        }
+        body.night .progress-footer {
+          background: rgba(10, 20, 15, 0.92);
+          border-top-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .progress-card {
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.3);
+          box-shadow: none;
+        }
+        body.night .progress-track {
+          background: rgba(60, 177, 121, 0.2);
+        }
+        body.night .progress-bar {
+          background: linear-gradient(135deg, #3cb179, #67f0aa);
+          box-shadow: 0 10px 25px rgba(60, 177, 121, 0.35);
+        }
+        body.night .snapshot-tile,
+        body.night .story-tile {
+          background: rgba(60, 177, 121, 0.18);
+          border-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .pill {
+          background: rgba(60, 177, 121, 0.2);
+          color: rgba(232, 245, 236, 0.85);
+          border-color: rgba(60, 177, 121, 0.35);
+        }
+        body.night .nav-links {
+          background: #0f1d17;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: -24px 0 60px rgba(0, 0, 0, 0.55);
         }
         body.night .nav-links a,
         body.night .nav-links summary,
         body.night .mode-toggle {
-          color: rgba(244, 246, 255, 0.78);
+          color: rgba(232, 245, 236, 0.78);
         }
         body.night .nav-dropdown {
-          background: #1f2336;
-          border-color: rgba(92, 105, 210, 0.25);
-          box-shadow: 0 24px 44px rgba(8, 10, 18, 0.6);
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
         }
         body.night .nav-dropdown a:hover,
         body.night .nav-dropdown a:focus {
-          background: rgba(127, 140, 255, 0.18);
-          color: #f4f6ff;
+          background: rgba(60, 177, 121, 0.22);
+          color: #e8f5ec;
         }
         body.night .mode-toggle {
-          background: rgba(127, 140, 255, 0.12);
-          border-color: rgba(92, 105, 210, 0.25);
+          background: rgba(60, 177, 121, 0.16);
+          border-color: rgba(60, 177, 121, 0.3);
+        }
+        body.night .menu-overlay {
+          background: rgba(4, 12, 8, 0.7);
         }
         body.night footer {
-          color: rgba(244, 246, 255, 0.6);
+          color: rgba(232, 245, 236, 0.7);
         }
       `;
       document.head.appendChild(nightStyles);

--- a/arecibo-line-calculator.html
+++ b/arecibo-line-calculator.html
@@ -7,15 +7,15 @@
     <style>
       :root {
         color-scheme: light;
-        --page-bg: #f6f1eb;
+        --page-bg: #f0f8f3;
         --card-bg: #ffffff;
-        --accent: #ff7a3d;
-        --accent-soft: rgba(255, 122, 61, 0.14);
-        --accent-strong: #f5580f;
-        --text: #241c18;
-        --muted: #6a5d58;
-        --border: #e5d8cf;
-        --shadow: 0px 28px 60px rgba(208, 174, 150, 0.32);
+        --accent: #3cb179;
+        --accent-soft: rgba(60, 177, 121, 0.14);
+        --accent-strong: #2d8f60;
+        --text: #1f3327;
+        --muted: #4f6b59;
+        --border: #c8e5d2;
+        --shadow: 0px 28px 60px rgba(92, 170, 120, 0.28);
         font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
       }
 
@@ -27,8 +27,8 @@
         margin: 0;
         min-height: 100vh;
         background:
-          radial-gradient(circle at top right, rgba(255, 198, 145, 0.28), transparent 62%),
-          radial-gradient(circle at bottom left, rgba(255, 174, 120, 0.22), transparent 55%),
+          radial-gradient(circle at top right, rgba(92, 214, 153, 0.26), transparent 62%),
+          radial-gradient(circle at bottom left, rgba(78, 176, 120, 0.2), transparent 55%),
           var(--page-bg);
         color: var(--text);
         display: flex;
@@ -40,63 +40,232 @@
       }
 
       .nav-shell {
-        max-width: 1120px;
+        max-width: 1080px;
         margin: 0 auto;
         display: flex;
-        justify-content: space-between;
         align-items: center;
+        justify-content: space-between;
         gap: 2rem;
       }
 
       .brand {
         display: grid;
-        gap: 0.2rem;
+        gap: 0.1rem;
       }
 
       .brand small {
-        font-size: 0.72rem;
+        font-size: 0.75rem;
+        letter-spacing: 0.3em;
         font-weight: 600;
-        letter-spacing: 0.28em;
         text-transform: uppercase;
         color: var(--muted);
       }
 
       .brand strong {
-        font-size: 1.2rem;
+        font-size: 1.15rem;
         font-weight: 700;
       }
 
-      .nav-links {
-        display: flex;
-        gap: 1.25rem;
+      .menu-toggle {
+        border: none;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.65rem;
         font-size: 0.95rem;
-        color: var(--muted);
         font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
       }
 
-      .nav-links a {
-        color: inherit;
-        text-decoration: none;
+      .menu-toggle:hover,
+      .menu-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-strong);
+        outline: none;
+      }
+
+      .menu-icon {
         position: relative;
-        padding-bottom: 0.2rem;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: background 0.2s ease;
       }
 
-      .nav-links a::after {
+      .menu-icon::before,
+      .menu-icon::after {
         content: "";
         position: absolute;
         left: 0;
-        bottom: 0;
-        width: 100%;
+        width: 18px;
         height: 2px;
-        background: var(--accent);
-        transform: scaleX(0);
-        transform-origin: left;
+        background: currentColor;
+        border-radius: 999px;
         transition: transform 0.2s ease;
       }
 
-      .nav-links a:hover::after,
-      .nav-links a:focus-visible::after {
-        transform: scaleX(1);
+      .menu-icon::before {
+        top: -6px;
+      }
+
+      .menu-icon::after {
+        top: 6px;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon {
+        background: transparent;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::before {
+        transform: translateY(6px) rotate(45deg);
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::after {
+        transform: translateY(-6px) rotate(-45deg);
+      }
+
+      .menu-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .nav-links {
+        position: fixed;
+        inset: 0 0 0 auto;
+        width: min(320px, 85vw);
+        background: var(--card-bg);
+        border-left: 1px solid var(--border);
+        box-shadow: -24px 0 60px rgba(17, 37, 23, 0.18);
+        padding: 6rem 1.75rem 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 20;
+      }
+
+      body.menu-open .nav-links {
+        transform: translateX(0);
+      }
+
+      .nav-links a,
+      .nav-links summary {
+        color: var(--muted);
+        font-weight: 600;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.35rem;
+        padding: 0.75rem 1rem;
+        border-radius: 14px;
+        transition: background 0.2s ease, color 0.2s ease;
+      }
+
+      .nav-links summary {
+        list-style: none;
+      }
+
+      .nav-links summary::-webkit-details-marker,
+      .nav-links summary::marker {
+        display: none;
+      }
+
+      .nav-links details {
+        width: 100%;
+      }
+
+      .nav-links summary::after {
+        content: "▾";
+        font-size: 0.75rem;
+        transition: transform 0.2s ease;
+      }
+
+      .nav-links details[open] > summary {
+        color: var(--accent-strong);
+      }
+
+      .nav-links details[open] > summary::after {
+        transform: rotate(180deg);
+      }
+
+      .nav-dropdown {
+        margin-top: 0.35rem;
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 0.5rem;
+        display: grid;
+        gap: 0.35rem;
+        box-shadow: none;
+      }
+
+      .nav-dropdown a {
+        font-weight: 600;
+        color: var(--muted);
+        padding: 0.45rem 0.75rem;
+        border-radius: 10px;
+        transition: background 0.2s ease, color 0.2s ease;
+      }
+
+      .nav-dropdown a:hover,
+      .nav-dropdown a:focus-visible {
+        color: var(--accent-strong);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .nav-links summary:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 4px;
+      }
+
+      .mode-toggle {
+        border: 1px solid rgba(60, 177, 121, 0.3);
+        background: #fff;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        color: var(--muted);
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+        justify-content: center;
+      }
+
+      .mode-toggle:hover,
+      .mode-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .menu-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 35, 23, 0.4);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 10;
+      }
+
+      body.menu-open .menu-overlay {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      body.menu-open {
+        overflow: hidden;
       }
 
       main {
@@ -224,7 +393,7 @@
       textarea:focus {
         outline: none;
         border-color: var(--accent);
-        box-shadow: 0 0 0 4px rgba(255, 122, 61, 0.18);
+        box-shadow: 0 0 0 4px rgba(60, 177, 121, 0.2);
       }
 
       textarea {
@@ -248,7 +417,7 @@
         border-radius: 22px;
         padding: 1.6rem;
         border: 1px solid var(--border);
-        background: #fff8f4;
+        background: #f3fbf6;
         display: grid;
         gap: 0.45rem;
       }
@@ -339,17 +508,37 @@
   <body>
     <header>
       <div class="nav-shell">
-        <div class="brand">
-          <small>ÅSE STEINSLAND STUDIO</small>
-          <strong>ALÅ — Arecibo Line Translator</strong>
-        </div>
-        <nav class="nav-links" aria-label="Page sections">
-          <a href="#method">Method</a>
-          <a href="#calculator">Calculator</a>
-          <a href="#interpretation">Interpretation</a>
-        </nav>
+        <a class="brand" href="/">
+          <small>ÅSE STEINSLAND</small>
+          <strong>Numerologist Studio</strong>
+        </a>
+        <button class="menu-toggle" type="button" id="menuToggle" aria-expanded="false" aria-controls="primaryNav">
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label">Menu</span>
+        </button>
       </div>
+      <nav class="nav-links" id="primaryNav" aria-label="Primary" aria-hidden="true">
+        <a href="/intake/">Intake</a>
+        <a href="/cms/">CMS</a>
+        <a href="/roadmap.html">Roadmap</a>
+        <a href="/calculators.html">Calculators</a>
+        <a href="/arecibo.html">Arecibo Line</a>
+        <a href="/articles.html">Articles</a>
+        <details>
+          <summary>About Nummerology</summary>
+          <div class="nav-dropdown">
+            <a href="/about.html">Our Story</a>
+            <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+            <a href="/about-academy.html">Academy &amp; AI</a>
+          </div>
+        </details>
+        <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+          <span aria-hidden="true">🌞</span>
+          Night mode
+        </button>
+      </nav>
     </header>
+    <div class="menu-overlay" id="menuOverlay" hidden></div>
 
     <main>
       <div class="layout">
@@ -462,6 +651,159 @@
     </footer>
 
     <script>
+      const modeToggle = document.getElementById("modeToggle");
+      const menuToggleButton = document.getElementById("menuToggle");
+      const primaryNav = document.getElementById("primaryNav");
+      const menuOverlay = document.getElementById("menuOverlay");
+
+      const setMenuState = (open) => {
+        if (menuToggleButton) {
+          menuToggleButton.setAttribute("aria-expanded", String(open));
+        }
+        if (primaryNav) {
+          primaryNav.setAttribute("aria-hidden", String(!open));
+        }
+        if (menuOverlay) {
+          if (open) {
+            menuOverlay.removeAttribute("hidden");
+          } else {
+            menuOverlay.setAttribute("hidden", "");
+          }
+        }
+        document.body.classList.toggle("menu-open", open);
+      };
+
+      const closeMenu = () => {
+        setMenuState(false);
+        primaryNav?.querySelectorAll("details[open]").forEach((detail) => {
+          detail.removeAttribute("open");
+        });
+      };
+      const openMenu = () => setMenuState(true);
+
+      menuToggleButton?.addEventListener("click", () => {
+        const expanded = menuToggleButton.getAttribute("aria-expanded") === "true";
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      menuOverlay?.addEventListener("click", closeMenu);
+
+      primaryNav?.querySelectorAll("a").forEach((link) => {
+        link.addEventListener("click", closeMenu);
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          const expanded = menuToggleButton?.getAttribute("aria-expanded") === "true";
+          if (expanded) {
+            closeMenu();
+            menuToggleButton?.focus();
+          }
+        }
+      });
+
+
+      if (modeToggle) {
+        const setMode = (night) => {
+          document.body.classList.toggle("night", night);
+          modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
+          modeToggle.innerHTML = night
+            ? '<span aria-hidden="true">🌙</span> Light mode'
+            : '<span aria-hidden="true">🌞</span> Night mode';
+          localStorage.setItem("numerologist-mode", night ? "night" : "day");
+        };
+
+        modeToggle.addEventListener("click", () => {
+          closeMenu();
+          setMode(!document.body.classList.contains("night"));
+        });
+
+        const savedMode = localStorage.getItem("numerologist-mode");
+        if (savedMode === "night") {
+          setMode(true);
+        }
+      }
+      const nightStyles = document.createElement("style");
+      nightStyles.textContent = `
+        body.night {
+          background: #0e1713;
+          color: #e8f5ec;
+        }
+        body.night header,
+        body.night main {
+          background: transparent;
+        }
+        body.night .hero-card,
+        body.night .step-card,
+        body.night .snapshot-card,
+        body.night .stories-card {
+          background: #13231b;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
+        }
+        body.night .progress-footer {
+          background: rgba(10, 20, 15, 0.92);
+          border-top-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .progress-card {
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.3);
+          box-shadow: none;
+        }
+        body.night .progress-track {
+          background: rgba(60, 177, 121, 0.2);
+        }
+        body.night .progress-bar {
+          background: linear-gradient(135deg, #3cb179, #67f0aa);
+          box-shadow: 0 10px 25px rgba(60, 177, 121, 0.35);
+        }
+        body.night .snapshot-tile,
+        body.night .story-tile {
+          background: rgba(60, 177, 121, 0.18);
+          border-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .pill {
+          background: rgba(60, 177, 121, 0.2);
+          color: rgba(232, 245, 236, 0.85);
+          border-color: rgba(60, 177, 121, 0.35);
+        }
+        body.night .nav-links {
+          background: #0f1d17;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: -24px 0 60px rgba(0, 0, 0, 0.55);
+        }
+        body.night .nav-links a,
+        body.night .nav-links summary,
+        body.night .mode-toggle {
+          color: rgba(232, 245, 236, 0.78);
+        }
+        body.night .nav-dropdown {
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
+        }
+        body.night .nav-dropdown a:hover,
+        body.night .nav-dropdown a:focus {
+          background: rgba(60, 177, 121, 0.22);
+          color: #e8f5ec;
+        }
+        body.night .mode-toggle {
+          background: rgba(60, 177, 121, 0.16);
+          border-color: rgba(60, 177, 121, 0.3);
+        }
+        body.night .menu-overlay {
+          background: rgba(4, 12, 8, 0.7);
+        }
+        body.night footer {
+          color: rgba(232, 245, 236, 0.7);
+        }
+      `;
+      document.head.appendChild(nightStyles);
+
       const cosmicField = document.getElementById("cosmic-input");
       const earthField = document.getElementById("earth-input");
       const cosmicTotalEl = document.getElementById("cosmic-total");

--- a/arecibo.html
+++ b/arecibo.html
@@ -7,16 +7,16 @@
     <style>
       :root {
         color-scheme: light;
-        --page-bg: #fdf7f0;
+        --page-bg: #f0f8f3;
         --card-bg: #ffffff;
-        --card-elevated: #fffaf4;
-        --border: #f0dfcd;
-        --text: #2a2220;
-        --muted: #6f5b53;
-        --accent: #ff8a3d;
-        --accent-soft: rgba(255, 138, 61, 0.12);
-        --accent-strong: #f55d0d;
-        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        --card-elevated: #f7fcf8;
+        --border: #c8e5d2;
+        --text: #1f3327;
+        --muted: #4f6b59;
+        --accent: #3cb179;
+        --accent-soft: rgba(60, 177, 121, 0.12);
+        --accent-strong: #2d8f60;
+        --shadow: 0px 30px 60px rgba(92, 170, 120, 0.28);
         font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
       }
 
@@ -27,8 +27,8 @@
       body {
         margin: 0;
         min-height: 100vh;
-        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
-          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        background: radial-gradient(circle at top right, rgba(94, 214, 149, 0.32), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(72, 176, 120, 0.2), transparent 55%), var(--page-bg);
         color: var(--text);
         display: flex;
         flex-direction: column;
@@ -70,11 +70,93 @@
         font-weight: 700;
       }
 
-      .nav-links {
-        display: flex;
+      .menu-toggle {
+        border: none;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        display: inline-flex;
         align-items: center;
-        gap: 1.25rem;
+        gap: 0.65rem;
         font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+      }
+
+      .menu-toggle:hover,
+      .menu-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-strong);
+        outline: none;
+      }
+
+      .menu-icon {
+        position: relative;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: background 0.2s ease;
+      }
+
+      .menu-icon::before,
+      .menu-icon::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: transform 0.2s ease;
+      }
+
+      .menu-icon::before {
+        top: -6px;
+      }
+
+      .menu-icon::after {
+        top: 6px;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon {
+        background: transparent;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::before {
+        transform: translateY(6px) rotate(45deg);
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::after {
+        transform: translateY(-6px) rotate(-45deg);
+      }
+
+      .menu-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .nav-links {
+        position: fixed;
+        inset: 0 0 0 auto;
+        width: min(320px, 85vw);
+        background: var(--card-bg);
+        border-left: 1px solid var(--border);
+        box-shadow: -24px 0 60px rgba(17, 37, 23, 0.18);
+        padding: 6rem 1.75rem 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 20;
+      }
+
+      body.menu-open .nav-links {
+        transform: translateX(0);
       }
 
       .nav-links a,
@@ -82,10 +164,13 @@
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        display: inline-flex;
+        display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: 0.35rem;
-        transition: color 0.2s ease;
+        padding: 0.75rem 1rem;
+        border-radius: 14px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-links summary {
@@ -97,18 +182,18 @@
         display: none;
       }
 
+      .nav-links details {
+        width: 100%;
+      }
+
       .nav-links summary::after {
         content: "▾";
-        font-size: 0.65rem;
+        font-size: 0.75rem;
         transition: transform 0.2s ease;
       }
 
-      .nav-links details {
-        position: relative;
-      }
-
       .nav-links details[open] > summary {
-        color: var(--text);
+        color: var(--accent-strong);
       }
 
       .nav-links details[open] > summary::after {
@@ -116,30 +201,27 @@
       }
 
       .nav-dropdown {
-        position: absolute;
-        top: calc(100% + 0.75rem);
-        left: 0;
-        min-width: 14rem;
+        margin-top: 0.35rem;
         background: var(--card-bg);
         border: 1px solid var(--border);
-        border-radius: 16px;
-        padding: 0.75rem;
+        border-radius: 14px;
+        padding: 0.5rem;
         display: grid;
         gap: 0.35rem;
-        box-shadow: var(--shadow);
-        z-index: 10;
+        box-shadow: none;
       }
 
       .nav-dropdown a {
         font-weight: 600;
         color: var(--muted);
-        padding: 0.35rem 0.5rem;
+        padding: 0.45rem 0.75rem;
         border-radius: 10px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-dropdown a:hover,
-      .nav-dropdown a:focus {
-        color: var(--text);
+      .nav-dropdown a:focus-visible {
+        color: var(--accent-strong);
         background: var(--accent-soft);
         outline: none;
       }
@@ -150,17 +232,44 @@
       }
 
       .mode-toggle {
-        border: 1px solid rgba(0, 0, 0, 0.05);
+        border: 1px solid rgba(60, 177, 121, 0.3);
         background: #fff;
         border-radius: 999px;
-        padding: 0.45rem 1.1rem;
+        padding: 0.6rem 1.1rem;
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
         color: var(--muted);
         font-weight: 600;
-        box-shadow: var(--shadow);
         cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+        justify-content: center;
+      }
+
+      .mode-toggle:hover,
+      .mode-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .menu-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 35, 23, 0.4);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 10;
+      }
+
+      body.menu-open .menu-overlay {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      body.menu-open {
+        overflow: hidden;
       }
 
       main {
@@ -265,7 +374,7 @@
       .timeline li {
         display: grid;
         gap: 0.4rem;
-        border-left: 3px solid rgba(255, 138, 61, 0.25);
+        border-left: 3px solid rgba(60, 177, 121, 0.25);
         padding-left: 1.25rem;
       }
 
@@ -282,10 +391,10 @@
       }
 
       .cta {
-        background: linear-gradient(135deg, rgba(255, 138, 61, 0.18), rgba(255, 209, 168, 0.28));
+        background: linear-gradient(135deg, rgba(60, 177, 121, 0.2), rgba(171, 238, 198, 0.3));
         border-radius: 26px;
         padding: 2.5rem;
-        border: 1px solid rgba(255, 138, 61, 0.2);
+        border: 1px solid rgba(60, 177, 121, 0.2);
         display: grid;
         gap: 1rem;
         text-align: center;
@@ -311,7 +420,7 @@
         padding: 0.75rem 1.75rem;
         border-radius: 999px;
         font-weight: 600;
-        box-shadow: 0 16px 30px rgba(255, 138, 61, 0.35);
+        box-shadow: 0 16px 30px rgba(45, 143, 96, 0.35);
       }
 
       footer {
@@ -337,8 +446,6 @@
         }
 
         .nav-shell {
-          flex-direction: column;
-          align-items: flex-start;
           gap: 1rem;
         }
 
@@ -354,17 +461,6 @@
       }
 
       @media (max-width: 480px) {
-        .nav-links {
-          flex-direction: column;
-          align-items: flex-start;
-          width: 100%;
-        }
-
-        .nav-links a,
-        .nav-links summary,
-        .mode-toggle {
-          width: 100%;
-        }
       }
     </style>
   </head>
@@ -375,28 +471,33 @@
           <small>ÅSE STEINSLAND</small>
           <strong>Numerologist Studio</strong>
         </a>
-        <nav class="nav-links" aria-label="Primary">
-          <a href="/intake/">Intake</a>
-          <a href="/cms/">CMS</a>
-          <a href="/roadmap.html">Roadmap</a>
-          <a href="/calculators.html">Calculators</a>
-          <a href="/arecibo.html" aria-current="page">Arecibo Line</a>
-          <a href="/articles.html">Articles</a>
-          <details>
-            <summary>About Nummerology</summary>
-            <div class="nav-dropdown">
-              <a href="/about.html">Our Story</a>
-              <a href="/about-vision-mission.html">Vision &amp; Mission</a>
-              <a href="/about-academy.html">Academy &amp; AI</a>
-            </div>
-          </details>
-          <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
-            <span aria-hidden="true">🌞</span>
-            Night mode
-          </button>
-        </nav>
+        <button class="menu-toggle" type="button" id="menuToggle" aria-expanded="false" aria-controls="primaryNav">
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label">Menu</span>
+        </button>
       </div>
+      <nav class="nav-links" id="primaryNav" aria-label="Primary" aria-hidden="true">
+        <a href="/intake/">Intake</a>
+        <a href="/cms/">CMS</a>
+        <a href="/roadmap.html">Roadmap</a>
+        <a href="/calculators.html">Calculators</a>
+        <a href="/arecibo.html">Arecibo Line</a>
+        <a href="/articles.html">Articles</a>
+        <details>
+          <summary>About Nummerology</summary>
+          <div class="nav-dropdown">
+            <a href="/about.html">Our Story</a>
+            <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+            <a href="/about-academy.html">Academy &amp; AI</a>
+          </div>
+        </details>
+        <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+          <span aria-hidden="true">🌞</span>
+          Night mode
+        </button>
+      </nav>
     </header>
+    <div class="menu-overlay" id="menuOverlay" hidden></div>
     <main>
       <div class="layout">
         <section class="hero-card" aria-labelledby="arecibo-title">
@@ -480,6 +581,61 @@
     <footer>© <span id="year"></span> Numerologist Studio. Guided by Åse Steinsland.</footer>
     <script>
       const modeToggle = document.getElementById("modeToggle");
+      const menuToggleButton = document.getElementById("menuToggle");
+      const primaryNav = document.getElementById("primaryNav");
+      const menuOverlay = document.getElementById("menuOverlay");
+
+      const setMenuState = (open) => {
+        if (menuToggleButton) {
+          menuToggleButton.setAttribute("aria-expanded", String(open));
+        }
+        if (primaryNav) {
+          primaryNav.setAttribute("aria-hidden", String(!open));
+        }
+        if (menuOverlay) {
+          if (open) {
+            menuOverlay.removeAttribute("hidden");
+          } else {
+            menuOverlay.setAttribute("hidden", "");
+          }
+        }
+        document.body.classList.toggle("menu-open", open);
+      };
+
+      const closeMenu = () => {
+        setMenuState(false);
+        primaryNav?.querySelectorAll("details[open]").forEach((detail) => {
+          detail.removeAttribute("open");
+        });
+      };
+      const openMenu = () => setMenuState(true);
+
+      menuToggleButton?.addEventListener("click", () => {
+        const expanded = menuToggleButton.getAttribute("aria-expanded") === "true";
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      menuOverlay?.addEventListener("click", closeMenu);
+
+      primaryNav?.querySelectorAll("a").forEach((link) => {
+        link.addEventListener("click", closeMenu);
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          const expanded = menuToggleButton?.getAttribute("aria-expanded") === "true";
+          if (expanded) {
+            closeMenu();
+            menuToggleButton?.focus();
+          }
+        }
+      });
+
+
       const setMode = (night) => {
         document.body.classList.toggle("night", night);
         modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
@@ -490,6 +646,7 @@
       };
 
       modeToggle.addEventListener("click", () => {
+        closeMenu();
         setMode(!document.body.classList.contains("night"));
       });
 
@@ -503,42 +660,76 @@
       const nightStyles = document.createElement("style");
       nightStyles.textContent = `
         body.night {
-          background: #101322;
-          color: #f4f6ff;
+          background: #0e1713;
+          color: #e8f5ec;
+        }
+        body.night header,
+        body.night main {
+          background: transparent;
         }
         body.night .hero-card,
-        body.night .insight,
-        body.night .timeline,
-        body.night .cta {
-          background: #171b2b;
-          border-color: rgba(92, 105, 210, 0.25);
+        body.night .step-card,
+        body.night .snapshot-card,
+        body.night .stories-card {
+          background: #13231b;
+          border-color: rgba(60, 177, 121, 0.25);
           box-shadow: none;
         }
-        body.night .cta {
-          background: linear-gradient(135deg, rgba(127, 140, 255, 0.18), rgba(92, 105, 210, 0.18));
-          border-color: rgba(92, 105, 210, 0.4);
+        body.night .progress-footer {
+          background: rgba(10, 20, 15, 0.92);
+          border-top-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .progress-card {
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.3);
+          box-shadow: none;
+        }
+        body.night .progress-track {
+          background: rgba(60, 177, 121, 0.2);
+        }
+        body.night .progress-bar {
+          background: linear-gradient(135deg, #3cb179, #67f0aa);
+          box-shadow: 0 10px 25px rgba(60, 177, 121, 0.35);
+        }
+        body.night .snapshot-tile,
+        body.night .story-tile {
+          background: rgba(60, 177, 121, 0.18);
+          border-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .pill {
+          background: rgba(60, 177, 121, 0.2);
+          color: rgba(232, 245, 236, 0.85);
+          border-color: rgba(60, 177, 121, 0.35);
+        }
+        body.night .nav-links {
+          background: #0f1d17;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: -24px 0 60px rgba(0, 0, 0, 0.55);
         }
         body.night .nav-links a,
         body.night .nav-links summary,
         body.night .mode-toggle {
-          color: rgba(244, 246, 255, 0.78);
+          color: rgba(232, 245, 236, 0.78);
         }
         body.night .nav-dropdown {
-          background: #1f2336;
-          border-color: rgba(92, 105, 210, 0.25);
-          box-shadow: 0 24px 44px rgba(8, 10, 18, 0.6);
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
         }
         body.night .nav-dropdown a:hover,
         body.night .nav-dropdown a:focus {
-          background: rgba(127, 140, 255, 0.18);
-          color: #f4f6ff;
+          background: rgba(60, 177, 121, 0.22);
+          color: #e8f5ec;
         }
         body.night .mode-toggle {
-          background: rgba(127, 140, 255, 0.12);
-          border-color: rgba(92, 105, 210, 0.25);
+          background: rgba(60, 177, 121, 0.16);
+          border-color: rgba(60, 177, 121, 0.3);
+        }
+        body.night .menu-overlay {
+          background: rgba(4, 12, 8, 0.7);
         }
         body.night footer {
-          color: rgba(244, 246, 255, 0.6);
+          color: rgba(232, 245, 236, 0.7);
         }
       `;
       document.head.appendChild(nightStyles);

--- a/articles.html
+++ b/articles.html
@@ -7,16 +7,16 @@
     <style>
       :root {
         color-scheme: light;
-        --page-bg: #fdf7f0;
+        --page-bg: #f0f8f3;
         --card-bg: #ffffff;
-        --card-elevated: #fffaf4;
-        --border: #f0dfcd;
-        --text: #2a2220;
-        --muted: #6f5b53;
-        --accent: #ff8a3d;
-        --accent-soft: rgba(255, 138, 61, 0.12);
-        --accent-strong: #f55d0d;
-        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        --card-elevated: #f7fcf8;
+        --border: #c8e5d2;
+        --text: #1f3327;
+        --muted: #4f6b59;
+        --accent: #3cb179;
+        --accent-soft: rgba(60, 177, 121, 0.12);
+        --accent-strong: #2d8f60;
+        --shadow: 0px 30px 60px rgba(92, 170, 120, 0.28);
         font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
       }
 
@@ -27,8 +27,8 @@
       body {
         margin: 0;
         min-height: 100vh;
-        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
-          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        background: radial-gradient(circle at top right, rgba(94, 214, 149, 0.32), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(72, 176, 120, 0.2), transparent 55%), var(--page-bg);
         color: var(--text);
         display: flex;
         flex-direction: column;
@@ -70,11 +70,93 @@
         font-weight: 700;
       }
 
-      .nav-links {
-        display: flex;
+      .menu-toggle {
+        border: none;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        display: inline-flex;
         align-items: center;
-        gap: 1.25rem;
+        gap: 0.65rem;
         font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+      }
+
+      .menu-toggle:hover,
+      .menu-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-strong);
+        outline: none;
+      }
+
+      .menu-icon {
+        position: relative;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: background 0.2s ease;
+      }
+
+      .menu-icon::before,
+      .menu-icon::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: transform 0.2s ease;
+      }
+
+      .menu-icon::before {
+        top: -6px;
+      }
+
+      .menu-icon::after {
+        top: 6px;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon {
+        background: transparent;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::before {
+        transform: translateY(6px) rotate(45deg);
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::after {
+        transform: translateY(-6px) rotate(-45deg);
+      }
+
+      .menu-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .nav-links {
+        position: fixed;
+        inset: 0 0 0 auto;
+        width: min(320px, 85vw);
+        background: var(--card-bg);
+        border-left: 1px solid var(--border);
+        box-shadow: -24px 0 60px rgba(17, 37, 23, 0.18);
+        padding: 6rem 1.75rem 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 20;
+      }
+
+      body.menu-open .nav-links {
+        transform: translateX(0);
       }
 
       .nav-links a,
@@ -82,10 +164,13 @@
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        display: inline-flex;
+        display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: 0.35rem;
-        transition: color 0.2s ease;
+        padding: 0.75rem 1rem;
+        border-radius: 14px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-links summary {
@@ -97,18 +182,18 @@
         display: none;
       }
 
+      .nav-links details {
+        width: 100%;
+      }
+
       .nav-links summary::after {
         content: "▾";
-        font-size: 0.65rem;
+        font-size: 0.75rem;
         transition: transform 0.2s ease;
       }
 
-      .nav-links details {
-        position: relative;
-      }
-
       .nav-links details[open] > summary {
-        color: var(--text);
+        color: var(--accent-strong);
       }
 
       .nav-links details[open] > summary::after {
@@ -116,30 +201,27 @@
       }
 
       .nav-dropdown {
-        position: absolute;
-        top: calc(100% + 0.75rem);
-        left: 0;
-        min-width: 14rem;
+        margin-top: 0.35rem;
         background: var(--card-bg);
         border: 1px solid var(--border);
-        border-radius: 16px;
-        padding: 0.75rem;
+        border-radius: 14px;
+        padding: 0.5rem;
         display: grid;
         gap: 0.35rem;
-        box-shadow: var(--shadow);
-        z-index: 10;
+        box-shadow: none;
       }
 
       .nav-dropdown a {
         font-weight: 600;
         color: var(--muted);
-        padding: 0.35rem 0.5rem;
+        padding: 0.45rem 0.75rem;
         border-radius: 10px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-dropdown a:hover,
-      .nav-dropdown a:focus {
-        color: var(--text);
+      .nav-dropdown a:focus-visible {
+        color: var(--accent-strong);
         background: var(--accent-soft);
         outline: none;
       }
@@ -150,17 +232,44 @@
       }
 
       .mode-toggle {
-        border: 1px solid rgba(0, 0, 0, 0.05);
+        border: 1px solid rgba(60, 177, 121, 0.3);
         background: #fff;
         border-radius: 999px;
-        padding: 0.45rem 1.1rem;
+        padding: 0.6rem 1.1rem;
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
         color: var(--muted);
         font-weight: 600;
-        box-shadow: var(--shadow);
         cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+        justify-content: center;
+      }
+
+      .mode-toggle:hover,
+      .mode-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .menu-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 35, 23, 0.4);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 10;
+      }
+
+      body.menu-open .menu-overlay {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      body.menu-open {
+        overflow: hidden;
       }
 
       main {
@@ -282,7 +391,7 @@
         gap: 0.35rem;
         padding: 1.15rem 1.35rem;
         border-radius: 18px;
-        border: 1px solid rgba(255, 138, 61, 0.2);
+        border: 1px solid rgba(60, 177, 121, 0.2);
         background: rgba(255, 255, 255, 0.6);
       }
 
@@ -327,8 +436,6 @@
         }
 
         .nav-shell {
-          flex-direction: column;
-          align-items: flex-start;
           gap: 1rem;
         }
 
@@ -343,17 +450,6 @@
       }
 
       @media (max-width: 480px) {
-        .nav-links {
-          flex-direction: column;
-          align-items: flex-start;
-          width: 100%;
-        }
-
-        .nav-links a,
-        .nav-links summary,
-        .mode-toggle {
-          width: 100%;
-        }
       }
     </style>
   </head>
@@ -364,28 +460,33 @@
           <small>ÅSE STEINSLAND</small>
           <strong>Numerologist Studio</strong>
         </a>
-        <nav class="nav-links" aria-label="Primary">
-          <a href="/intake/">Intake</a>
-          <a href="/cms/">CMS</a>
-          <a href="/roadmap.html">Roadmap</a>
-          <a href="/calculators.html">Calculators</a>
-          <a href="/arecibo.html">Arecibo Line</a>
-          <a href="/articles.html" aria-current="page">Articles</a>
-          <details>
-            <summary>About Nummerology</summary>
-            <div class="nav-dropdown">
-              <a href="/about.html">Our Story</a>
-              <a href="/about-vision-mission.html">Vision &amp; Mission</a>
-              <a href="/about-academy.html">Academy &amp; AI</a>
-            </div>
-          </details>
-          <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
-            <span aria-hidden="true">🌞</span>
-            Night mode
-          </button>
-        </nav>
+        <button class="menu-toggle" type="button" id="menuToggle" aria-expanded="false" aria-controls="primaryNav">
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label">Menu</span>
+        </button>
       </div>
+      <nav class="nav-links" id="primaryNav" aria-label="Primary" aria-hidden="true">
+        <a href="/intake/">Intake</a>
+        <a href="/cms/">CMS</a>
+        <a href="/roadmap.html">Roadmap</a>
+        <a href="/calculators.html">Calculators</a>
+        <a href="/arecibo.html">Arecibo Line</a>
+        <a href="/articles.html">Articles</a>
+        <details>
+          <summary>About Nummerology</summary>
+          <div class="nav-dropdown">
+            <a href="/about.html">Our Story</a>
+            <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+            <a href="/about-academy.html">Academy &amp; AI</a>
+          </div>
+        </details>
+        <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+          <span aria-hidden="true">🌞</span>
+          Night mode
+        </button>
+      </nav>
     </header>
+    <div class="menu-overlay" id="menuOverlay" hidden></div>
     <main>
       <div class="layout">
         <section class="intro" aria-labelledby="articles-title">
@@ -465,6 +566,61 @@
     <footer>© <span id="year"></span> Numerologist Studio. Guided by Åse Steinsland.</footer>
     <script>
       const modeToggle = document.getElementById("modeToggle");
+      const menuToggleButton = document.getElementById("menuToggle");
+      const primaryNav = document.getElementById("primaryNav");
+      const menuOverlay = document.getElementById("menuOverlay");
+
+      const setMenuState = (open) => {
+        if (menuToggleButton) {
+          menuToggleButton.setAttribute("aria-expanded", String(open));
+        }
+        if (primaryNav) {
+          primaryNav.setAttribute("aria-hidden", String(!open));
+        }
+        if (menuOverlay) {
+          if (open) {
+            menuOverlay.removeAttribute("hidden");
+          } else {
+            menuOverlay.setAttribute("hidden", "");
+          }
+        }
+        document.body.classList.toggle("menu-open", open);
+      };
+
+      const closeMenu = () => {
+        setMenuState(false);
+        primaryNav?.querySelectorAll("details[open]").forEach((detail) => {
+          detail.removeAttribute("open");
+        });
+      };
+      const openMenu = () => setMenuState(true);
+
+      menuToggleButton?.addEventListener("click", () => {
+        const expanded = menuToggleButton.getAttribute("aria-expanded") === "true";
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      menuOverlay?.addEventListener("click", closeMenu);
+
+      primaryNav?.querySelectorAll("a").forEach((link) => {
+        link.addEventListener("click", closeMenu);
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          const expanded = menuToggleButton?.getAttribute("aria-expanded") === "true";
+          if (expanded) {
+            closeMenu();
+            menuToggleButton?.focus();
+          }
+        }
+      });
+
+
       const setMode = (night) => {
         document.body.classList.toggle("night", night);
         modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
@@ -475,6 +631,7 @@
       };
 
       modeToggle.addEventListener("click", () => {
+        closeMenu();
         setMode(!document.body.classList.contains("night"));
       });
 
@@ -488,41 +645,76 @@
       const nightStyles = document.createElement("style");
       nightStyles.textContent = `
         body.night {
-          background: #101322;
-          color: #f4f6ff;
+          background: #0e1713;
+          color: #e8f5ec;
         }
-        body.night .intro,
-        body.night .collection-card,
-        body.night .latest {
-          background: #171b2b;
-          border-color: rgba(92, 105, 210, 0.25);
+        body.night header,
+        body.night main {
+          background: transparent;
+        }
+        body.night .hero-card,
+        body.night .step-card,
+        body.night .snapshot-card,
+        body.night .stories-card {
+          background: #13231b;
+          border-color: rgba(60, 177, 121, 0.25);
           box-shadow: none;
         }
-        body.night .latest-item {
-          background: rgba(30, 33, 58, 0.8);
-          border-color: rgba(92, 105, 210, 0.25);
+        body.night .progress-footer {
+          background: rgba(10, 20, 15, 0.92);
+          border-top-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .progress-card {
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.3);
+          box-shadow: none;
+        }
+        body.night .progress-track {
+          background: rgba(60, 177, 121, 0.2);
+        }
+        body.night .progress-bar {
+          background: linear-gradient(135deg, #3cb179, #67f0aa);
+          box-shadow: 0 10px 25px rgba(60, 177, 121, 0.35);
+        }
+        body.night .snapshot-tile,
+        body.night .story-tile {
+          background: rgba(60, 177, 121, 0.18);
+          border-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .pill {
+          background: rgba(60, 177, 121, 0.2);
+          color: rgba(232, 245, 236, 0.85);
+          border-color: rgba(60, 177, 121, 0.35);
+        }
+        body.night .nav-links {
+          background: #0f1d17;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: -24px 0 60px rgba(0, 0, 0, 0.55);
         }
         body.night .nav-links a,
         body.night .nav-links summary,
         body.night .mode-toggle {
-          color: rgba(244, 246, 255, 0.78);
+          color: rgba(232, 245, 236, 0.78);
         }
         body.night .nav-dropdown {
-          background: #1f2336;
-          border-color: rgba(92, 105, 210, 0.25);
-          box-shadow: 0 24px 44px rgba(8, 10, 18, 0.6);
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
         }
         body.night .nav-dropdown a:hover,
         body.night .nav-dropdown a:focus {
-          background: rgba(127, 140, 255, 0.18);
-          color: #f4f6ff;
+          background: rgba(60, 177, 121, 0.22);
+          color: #e8f5ec;
         }
         body.night .mode-toggle {
-          background: rgba(127, 140, 255, 0.12);
-          border-color: rgba(92, 105, 210, 0.25);
+          background: rgba(60, 177, 121, 0.16);
+          border-color: rgba(60, 177, 121, 0.3);
+        }
+        body.night .menu-overlay {
+          background: rgba(4, 12, 8, 0.7);
         }
         body.night footer {
-          color: rgba(244, 246, 255, 0.6);
+          color: rgba(232, 245, 236, 0.7);
         }
       `;
       document.head.appendChild(nightStyles);

--- a/calculators.html
+++ b/calculators.html
@@ -7,16 +7,16 @@
     <style>
       :root {
         color-scheme: light;
-        --page-bg: #fdf7f0;
+        --page-bg: #f0f8f3;
         --card-bg: #ffffff;
-        --card-elevated: #fffaf4;
-        --border: #f0dfcd;
-        --text: #2a2220;
-        --muted: #6f5b53;
-        --accent: #ff8a3d;
-        --accent-soft: rgba(255, 138, 61, 0.1);
-        --accent-strong: #f55d0d;
-        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        --card-elevated: #f7fcf8;
+        --border: #c8e5d2;
+        --text: #1f3327;
+        --muted: #4f6b59;
+        --accent: #3cb179;
+        --accent-soft: rgba(60, 177, 121, 0.12);
+        --accent-strong: #2d8f60;
+        --shadow: 0px 30px 60px rgba(92, 170, 120, 0.28);
         font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
       }
 
@@ -27,8 +27,8 @@
       body {
         margin: 0;
         min-height: 100vh;
-        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
-          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        background: radial-gradient(circle at top right, rgba(94, 214, 149, 0.32), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(72, 176, 120, 0.2), transparent 55%), var(--page-bg);
         color: var(--text);
         display: flex;
         flex-direction: column;
@@ -70,11 +70,93 @@
         font-weight: 700;
       }
 
-      .nav-links {
-        display: flex;
+      .menu-toggle {
+        border: none;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        display: inline-flex;
         align-items: center;
-        gap: 1.25rem;
+        gap: 0.65rem;
         font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+      }
+
+      .menu-toggle:hover,
+      .menu-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-strong);
+        outline: none;
+      }
+
+      .menu-icon {
+        position: relative;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: background 0.2s ease;
+      }
+
+      .menu-icon::before,
+      .menu-icon::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: transform 0.2s ease;
+      }
+
+      .menu-icon::before {
+        top: -6px;
+      }
+
+      .menu-icon::after {
+        top: 6px;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon {
+        background: transparent;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::before {
+        transform: translateY(6px) rotate(45deg);
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::after {
+        transform: translateY(-6px) rotate(-45deg);
+      }
+
+      .menu-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .nav-links {
+        position: fixed;
+        inset: 0 0 0 auto;
+        width: min(320px, 85vw);
+        background: var(--card-bg);
+        border-left: 1px solid var(--border);
+        box-shadow: -24px 0 60px rgba(17, 37, 23, 0.18);
+        padding: 6rem 1.75rem 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 20;
+      }
+
+      body.menu-open .nav-links {
+        transform: translateX(0);
       }
 
       .nav-links a,
@@ -82,14 +164,13 @@
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        display: inline-flex;
+        display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: 0.35rem;
-        transition: color 0.2s ease;
-      }
-
-      .nav-links a[aria-current="page"] {
-        color: var(--accent-strong);
+        padding: 0.75rem 1rem;
+        border-radius: 14px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-links summary {
@@ -101,18 +182,18 @@
         display: none;
       }
 
+      .nav-links details {
+        width: 100%;
+      }
+
       .nav-links summary::after {
         content: "▾";
-        font-size: 0.65rem;
+        font-size: 0.75rem;
         transition: transform 0.2s ease;
       }
 
-      .nav-links details {
-        position: relative;
-      }
-
       .nav-links details[open] > summary {
-        color: var(--text);
+        color: var(--accent-strong);
       }
 
       .nav-links details[open] > summary::after {
@@ -120,32 +201,75 @@
       }
 
       .nav-dropdown {
-        position: absolute;
-        top: calc(100% + 0.75rem);
-        left: 0;
-        min-width: 14rem;
+        margin-top: 0.35rem;
         background: var(--card-bg);
         border: 1px solid var(--border);
-        border-radius: 16px;
-        padding: 0.75rem;
+        border-radius: 14px;
+        padding: 0.5rem;
         display: grid;
         gap: 0.35rem;
-        box-shadow: var(--shadow);
-        z-index: 10;
+        box-shadow: none;
       }
 
       .nav-dropdown a {
         font-weight: 600;
         color: var(--muted);
-        padding: 0.35rem 0.5rem;
+        padding: 0.45rem 0.75rem;
         border-radius: 10px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-dropdown a:hover,
-      .nav-dropdown a:focus {
-        color: var(--text);
+      .nav-dropdown a:focus-visible {
+        color: var(--accent-strong);
         background: var(--accent-soft);
         outline: none;
+      }
+
+      .nav-links summary:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 4px;
+      }
+
+      .mode-toggle {
+        border: 1px solid rgba(60, 177, 121, 0.3);
+        background: #fff;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        color: var(--muted);
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+        justify-content: center;
+      }
+
+      .mode-toggle:hover,
+      .mode-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .menu-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 35, 23, 0.4);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 10;
+      }
+
+      body.menu-open .menu-overlay {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      body.menu-open {
+        overflow: hidden;
       }
 
       main {
@@ -242,13 +366,13 @@
       .btn-primary {
         background: var(--accent);
         color: #fff;
-        box-shadow: 0 10px 24px rgba(255, 138, 61, 0.25);
+        box-shadow: 0 10px 24px rgba(45, 143, 96, 0.25);
       }
 
       .btn-secondary {
         background: var(--accent-soft);
         color: var(--accent-strong);
-        border: 1px solid rgba(255, 138, 61, 0.25);
+        border: 1px solid rgba(60, 177, 121, 0.25);
       }
 
       footer {
@@ -263,8 +387,6 @@
         }
 
         .nav-shell {
-          flex-direction: column;
-          align-items: flex-start;
           gap: 1rem;
         }
 
@@ -285,24 +407,33 @@
           <small>ÅSE STEINSLAND</small>
           <strong>Numerologist Studio</strong>
         </a>
-        <nav class="nav-links" aria-label="Primary">
-          <a href="/intake/">Intake</a>
-          <a href="/cms/">CMS</a>
-          <a href="/roadmap.html">Roadmap</a>
-          <a href="/calculators.html" aria-current="page">Calculators</a>
-          <a href="/arecibo.html">Arecibo Line</a>
-          <a href="/articles.html">Articles</a>
-          <details>
-            <summary>About Nummerology</summary>
-            <div class="nav-dropdown">
-              <a href="/about.html">Our Story</a>
-              <a href="/about-vision-mission.html">Vision &amp; Mission</a>
-              <a href="/about-academy.html">Academy &amp; AI</a>
-            </div>
-          </details>
-        </nav>
+        <button class="menu-toggle" type="button" id="menuToggle" aria-expanded="false" aria-controls="primaryNav">
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label">Menu</span>
+        </button>
       </div>
+      <nav class="nav-links" id="primaryNav" aria-label="Primary" aria-hidden="true">
+        <a href="/intake/">Intake</a>
+        <a href="/cms/">CMS</a>
+        <a href="/roadmap.html">Roadmap</a>
+        <a href="/calculators.html">Calculators</a>
+        <a href="/arecibo.html">Arecibo Line</a>
+        <a href="/articles.html">Articles</a>
+        <details>
+          <summary>About Nummerology</summary>
+          <div class="nav-dropdown">
+            <a href="/about.html">Our Story</a>
+            <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+            <a href="/about-academy.html">Academy &amp; AI</a>
+          </div>
+        </details>
+        <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+          <span aria-hidden="true">🌞</span>
+          Night mode
+        </button>
+      </nav>
     </header>
+    <div class="menu-overlay" id="menuOverlay" hidden></div>
     <main>
       <div class="layout">
         <div class="page-title">
@@ -376,5 +507,160 @@
       </div>
     </main>
     <footer>Crafted for Åse Steinsland’s Numerologist Studio — explore each calculator as you prepare your reading.</footer>
+    <script>
+      const modeToggle = document.getElementById("modeToggle");
+      const menuToggleButton = document.getElementById("menuToggle");
+      const primaryNav = document.getElementById("primaryNav");
+      const menuOverlay = document.getElementById("menuOverlay");
+
+      const setMenuState = (open) => {
+        if (menuToggleButton) {
+          menuToggleButton.setAttribute("aria-expanded", String(open));
+        }
+        if (primaryNav) {
+          primaryNav.setAttribute("aria-hidden", String(!open));
+        }
+        if (menuOverlay) {
+          if (open) {
+            menuOverlay.removeAttribute("hidden");
+          } else {
+            menuOverlay.setAttribute("hidden", "");
+          }
+        }
+        document.body.classList.toggle("menu-open", open);
+      };
+
+      const closeMenu = () => {
+        setMenuState(false);
+        primaryNav?.querySelectorAll("details[open]").forEach((detail) => {
+          detail.removeAttribute("open");
+        });
+      };
+      const openMenu = () => setMenuState(true);
+
+      menuToggleButton?.addEventListener("click", () => {
+        const expanded = menuToggleButton.getAttribute("aria-expanded") === "true";
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      menuOverlay?.addEventListener("click", closeMenu);
+
+      primaryNav?.querySelectorAll("a").forEach((link) => {
+        link.addEventListener("click", closeMenu);
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          const expanded = menuToggleButton?.getAttribute("aria-expanded") === "true";
+          if (expanded) {
+            closeMenu();
+            menuToggleButton?.focus();
+          }
+        }
+      });
+
+
+      if (modeToggle) {
+        const setMode = (night) => {
+          document.body.classList.toggle("night", night);
+          modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
+          modeToggle.innerHTML = night
+            ? '<span aria-hidden="true">🌙</span> Light mode'
+            : '<span aria-hidden="true">🌞</span> Night mode';
+          localStorage.setItem("numerologist-mode", night ? "night" : "day");
+        };
+
+        modeToggle.addEventListener("click", () => {
+          closeMenu();
+          setMode(!document.body.classList.contains("night"));
+        });
+
+        const savedMode = localStorage.getItem("numerologist-mode");
+        if (savedMode === "night") {
+          setMode(true);
+        }
+      }
+      const nightStyles = document.createElement("style");
+      nightStyles.textContent = `
+        body.night {
+          background: #0e1713;
+          color: #e8f5ec;
+        }
+        body.night header,
+        body.night main {
+          background: transparent;
+        }
+        body.night .hero-card,
+        body.night .step-card,
+        body.night .snapshot-card,
+        body.night .stories-card {
+          background: #13231b;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
+        }
+        body.night .progress-footer {
+          background: rgba(10, 20, 15, 0.92);
+          border-top-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .progress-card {
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.3);
+          box-shadow: none;
+        }
+        body.night .progress-track {
+          background: rgba(60, 177, 121, 0.2);
+        }
+        body.night .progress-bar {
+          background: linear-gradient(135deg, #3cb179, #67f0aa);
+          box-shadow: 0 10px 25px rgba(60, 177, 121, 0.35);
+        }
+        body.night .snapshot-tile,
+        body.night .story-tile {
+          background: rgba(60, 177, 121, 0.18);
+          border-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .pill {
+          background: rgba(60, 177, 121, 0.2);
+          color: rgba(232, 245, 236, 0.85);
+          border-color: rgba(60, 177, 121, 0.35);
+        }
+        body.night .nav-links {
+          background: #0f1d17;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: -24px 0 60px rgba(0, 0, 0, 0.55);
+        }
+        body.night .nav-links a,
+        body.night .nav-links summary,
+        body.night .mode-toggle {
+          color: rgba(232, 245, 236, 0.78);
+        }
+        body.night .nav-dropdown {
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
+        }
+        body.night .nav-dropdown a:hover,
+        body.night .nav-dropdown a:focus {
+          background: rgba(60, 177, 121, 0.22);
+          color: #e8f5ec;
+        }
+        body.night .mode-toggle {
+          background: rgba(60, 177, 121, 0.16);
+          border-color: rgba(60, 177, 121, 0.3);
+        }
+        body.night .menu-overlay {
+          background: rgba(4, 12, 8, 0.7);
+        }
+        body.night footer {
+          color: rgba(232, 245, 236, 0.7);
+        }
+      `;
+      document.head.appendChild(nightStyles);
+    </script>
+    
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,16 +7,16 @@
     <style>
       :root {
         color-scheme: light;
-        --page-bg: #fdf7f0;
+        --page-bg: #f0f8f3;
         --card-bg: #ffffff;
-        --card-elevated: #fffaf4;
-        --border: #f0dfcd;
-        --text: #2a2220;
-        --muted: #6f5b53;
-        --accent: #ff8a3d;
-        --accent-soft: rgba(255, 138, 61, 0.1);
-        --accent-strong: #f55d0d;
-        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        --card-elevated: #f7fcf8;
+        --border: #c8e5d2;
+        --text: #1f3327;
+        --muted: #4f6b59;
+        --accent: #3cb179;
+        --accent-soft: rgba(60, 177, 121, 0.12);
+        --accent-strong: #2d8f60;
+        --shadow: 0px 30px 60px rgba(92, 170, 120, 0.28);
         font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
       }
 
@@ -27,8 +27,8 @@
       body {
         margin: 0;
         min-height: 100vh;
-        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
-          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        background: radial-gradient(circle at top right, rgba(94, 214, 149, 0.32), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(72, 176, 120, 0.2), transparent 55%), var(--page-bg);
         color: var(--text);
         display: flex;
         flex-direction: column;
@@ -70,11 +70,93 @@
         font-weight: 700;
       }
 
-      .nav-links {
-        display: flex;
+      .menu-toggle {
+        border: none;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        display: inline-flex;
         align-items: center;
-        gap: 1.25rem;
+        gap: 0.65rem;
         font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+      }
+
+      .menu-toggle:hover,
+      .menu-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-strong);
+        outline: none;
+      }
+
+      .menu-icon {
+        position: relative;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: background 0.2s ease;
+      }
+
+      .menu-icon::before,
+      .menu-icon::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: transform 0.2s ease;
+      }
+
+      .menu-icon::before {
+        top: -6px;
+      }
+
+      .menu-icon::after {
+        top: 6px;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon {
+        background: transparent;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::before {
+        transform: translateY(6px) rotate(45deg);
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::after {
+        transform: translateY(-6px) rotate(-45deg);
+      }
+
+      .menu-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .nav-links {
+        position: fixed;
+        inset: 0 0 0 auto;
+        width: min(320px, 85vw);
+        background: var(--card-bg);
+        border-left: 1px solid var(--border);
+        box-shadow: -24px 0 60px rgba(17, 37, 23, 0.18);
+        padding: 6rem 1.75rem 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 20;
+      }
+
+      body.menu-open .nav-links {
+        transform: translateX(0);
       }
 
       .nav-links a,
@@ -82,10 +164,13 @@
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        display: inline-flex;
+        display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: 0.35rem;
-        transition: color 0.2s ease;
+        padding: 0.75rem 1rem;
+        border-radius: 14px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-links summary {
@@ -97,18 +182,18 @@
         display: none;
       }
 
+      .nav-links details {
+        width: 100%;
+      }
+
       .nav-links summary::after {
         content: "▾";
-        font-size: 0.65rem;
+        font-size: 0.75rem;
         transition: transform 0.2s ease;
       }
 
-      .nav-links details {
-        position: relative;
-      }
-
       .nav-links details[open] > summary {
-        color: var(--text);
+        color: var(--accent-strong);
       }
 
       .nav-links details[open] > summary::after {
@@ -116,30 +201,27 @@
       }
 
       .nav-dropdown {
-        position: absolute;
-        top: calc(100% + 0.75rem);
-        left: 0;
-        min-width: 14rem;
+        margin-top: 0.35rem;
         background: var(--card-bg);
         border: 1px solid var(--border);
-        border-radius: 16px;
-        padding: 0.75rem;
+        border-radius: 14px;
+        padding: 0.5rem;
         display: grid;
         gap: 0.35rem;
-        box-shadow: var(--shadow);
-        z-index: 10;
+        box-shadow: none;
       }
 
       .nav-dropdown a {
         font-weight: 600;
         color: var(--muted);
-        padding: 0.35rem 0.5rem;
+        padding: 0.45rem 0.75rem;
         border-radius: 10px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-dropdown a:hover,
-      .nav-dropdown a:focus {
-        color: var(--text);
+      .nav-dropdown a:focus-visible {
+        color: var(--accent-strong);
         background: var(--accent-soft);
         outline: none;
       }
@@ -150,21 +232,44 @@
       }
 
       .mode-toggle {
-        border: 1px solid rgba(0, 0, 0, 0.05);
+        border: 1px solid rgba(60, 177, 121, 0.3);
         background: #fff;
         border-radius: 999px;
-        padding: 0.45rem 1.1rem;
+        padding: 0.6rem 1.1rem;
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        transition: transform 0.2s ease;
+        transition: transform 0.2s ease, background 0.2s ease;
+        justify-content: center;
       }
 
-      .mode-toggle:hover {
+      .mode-toggle:hover,
+      .mode-toggle:focus-visible {
         transform: translateY(-1px);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .menu-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 35, 23, 0.4);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 10;
+      }
+
+      body.menu-open .menu-overlay {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      body.menu-open {
+        overflow: hidden;
       }
 
       main {
@@ -183,7 +288,7 @@
       .hero-card {
         position: relative;
         border-radius: 36px;
-        background: linear-gradient(150deg, rgba(255, 243, 227, 0.9), rgba(255, 255, 255, 0.95));
+        background: linear-gradient(150deg, rgba(214, 244, 227, 0.9), rgba(255, 255, 255, 0.95));
         box-shadow: var(--shadow);
         padding: clamp(1.75rem, 3vw, 2.5rem);
         overflow: hidden;
@@ -195,7 +300,7 @@
         inset: -20% auto auto 55%;
         width: 420px;
         height: 420px;
-        background: radial-gradient(circle, rgba(255, 193, 125, 0.38) 0%, rgba(255, 193, 125, 0) 60%);
+        background: radial-gradient(circle, rgba(126, 220, 167, 0.38) 0%, rgba(126, 220, 167, 0) 60%);
         z-index: 0;
         pointer-events: none;
       }
@@ -241,7 +346,7 @@
         padding: 0.4rem 0.9rem;
         border-radius: 999px;
         background: rgba(255, 255, 255, 0.8);
-        border: 1px solid rgba(255, 181, 115, 0.35);
+        border: 1px solid rgba(60, 177, 121, 0.32);
         color: var(--muted);
         font-size: 0.85rem;
         font-weight: 600;
@@ -253,9 +358,9 @@
         left: 0;
         right: 0;
         padding: 1.25rem 2rem 1.75rem;
-        background: rgba(253, 247, 240, 0.9);
+        background: rgba(240, 248, 243, 0.92);
         backdrop-filter: blur(12px);
-        border-top: 1px solid rgba(240, 223, 205, 0.8);
+        border-top: 1px solid rgba(200, 229, 210, 0.8);
         display: flex;
         justify-content: center;
         z-index: 15;
@@ -264,12 +369,12 @@
       .progress-card {
         border-radius: 24px;
         background: var(--card-bg);
-        border: 1px solid rgba(255, 198, 141, 0.45);
+        border: 1px solid rgba(60, 177, 121, 0.35);
         padding: 1.25rem 1.75rem;
         display: grid;
         gap: 1rem;
         width: min(100%, 1080px);
-        box-shadow: 0 18px 40px rgba(228, 187, 147, 0.3);
+        box-shadow: 0 18px 40px rgba(60, 177, 121, 0.25);
       }
 
       .progress-top {
@@ -283,7 +388,7 @@
       .progress-track {
         position: relative;
         height: 12px;
-        background: rgba(255, 198, 141, 0.25);
+        background: rgba(60, 177, 121, 0.15);
         border-radius: 999px;
         overflow: hidden;
       }
@@ -292,15 +397,15 @@
         position: absolute;
         inset: 0;
         width: 0%;
-        background: linear-gradient(135deg, var(--accent), #ffd29d);
+        background: linear-gradient(135deg, var(--accent), #8ce3b1);
         border-radius: inherit;
         transition: width 0.4s ease;
-        box-shadow: 0 6px 18px rgba(245, 93, 13, 0.35);
+        box-shadow: 0 6px 18px rgba(45, 143, 96, 0.35);
       }
 
       .step-card {
         border-radius: 24px;
-        border: 1px solid rgba(255, 198, 141, 0.4);
+        border: 1px solid rgba(60, 177, 121, 0.3);
         padding: 1.75rem;
         display: grid;
         gap: 1.5rem;
@@ -323,7 +428,8 @@
       .step-card header span {
         font-weight: 600;
         color: var(--accent-strong);
-        background: rgba(255, 138, 61, 0.15);
+        background: var(--accent-soft);
+        border: 1px solid rgba(60, 177, 121, 0.2);
         padding: 0.25rem 0.7rem;
         border-radius: 999px;
         font-size: 0.85rem;
@@ -351,7 +457,7 @@
         font: inherit;
         background: #fff;
         color: inherit;
-        box-shadow: inset 0 1px 2px rgba(255, 176, 107, 0.15);
+        box-shadow: inset 0 1px 2px rgba(60, 177, 121, 0.15);
       }
 
       .actions {
@@ -377,13 +483,13 @@
       .btn-primary {
         background: linear-gradient(135deg, var(--accent), var(--accent-strong));
         color: #fff;
-        box-shadow: 0px 12px 28px rgba(245, 93, 13, 0.25);
+        box-shadow: 0px 12px 28px rgba(45, 143, 96, 0.25);
       }
 
       .btn-secondary {
         background: rgba(255, 255, 255, 0.9);
         color: var(--accent-strong);
-        border: 1px solid rgba(255, 138, 61, 0.3);
+        border: 1px solid rgba(60, 177, 121, 0.3);
       }
 
       .btn:hover {
@@ -392,7 +498,7 @@
 
       .snapshot-card {
         border-radius: 24px;
-        border: 1px solid rgba(255, 198, 141, 0.4);
+        border: 1px solid rgba(60, 177, 121, 0.3);
         padding: 1.75rem;
         background: #fff;
         display: grid;
@@ -406,7 +512,7 @@
       }
 
       .snapshot-tile {
-        background: rgba(255, 138, 61, 0.08);
+        background: rgba(60, 177, 121, 0.12);
         border-radius: 18px;
         padding: 1.1rem 1.2rem;
         display: grid;
@@ -427,7 +533,7 @@
       .stories-card {
         border-radius: 30px;
         background: #fff;
-        border: 1px solid rgba(255, 198, 141, 0.4);
+        border: 1px solid rgba(60, 177, 121, 0.3);
         padding: 1.75rem;
         display: grid;
         gap: 1.5rem;
@@ -446,12 +552,12 @@
 
       .story-tile {
         border-radius: 20px;
-        background: rgba(255, 255, 255, 0.65);
-        border: 1px solid rgba(255, 198, 141, 0.45);
+        background: rgba(255, 255, 255, 0.7);
+        border: 1px solid rgba(60, 177, 121, 0.35);
         padding: 1.25rem;
         display: grid;
         gap: 0.55rem;
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
       }
 
       .story-number {
@@ -478,13 +584,6 @@
 
       @media (max-width: 900px) {
         .nav-shell {
-          flex-direction: column;
-          align-items: flex-start;
-          gap: 1rem;
-        }
-
-        .nav-links {
-          flex-wrap: wrap;
           gap: 1rem;
         }
 
@@ -547,18 +646,6 @@
       }
 
       @media (max-width: 480px) {
-        .nav-links {
-          flex-direction: column;
-          align-items: flex-start;
-          width: 100%;
-        }
-
-        .nav-links a,
-        .nav-links summary,
-        .mode-toggle {
-          width: 100%;
-        }
-
         .story-grid {
           grid-template-columns: 1fr;
         }
@@ -576,28 +663,33 @@
           <small>ÅSE STEINSLAND</small>
           <strong>Numerologist Studio</strong>
         </a>
-        <nav class="nav-links" aria-label="Primary">
-          <a href="/intake/">Intake</a>
-          <a href="/cms/">CMS</a>
-          <a href="/roadmap.html">Roadmap</a>
-          <a href="/calculators.html">Calculators</a>
-          <a href="/arecibo.html">Arecibo Line</a>
-          <a href="/articles.html">Articles</a>
-          <details>
-            <summary>About Nummerology</summary>
-            <div class="nav-dropdown">
-              <a href="/about.html">Our Story</a>
-              <a href="/about-vision-mission.html">Vision &amp; Mission</a>
-              <a href="/about-academy.html">Academy &amp; AI</a>
-            </div>
-          </details>
-          <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
-            <span aria-hidden="true">🌞</span>
-            Night mode
-          </button>
-        </nav>
+        <button class="menu-toggle" type="button" id="menuToggle" aria-expanded="false" aria-controls="primaryNav">
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label">Menu</span>
+        </button>
       </div>
+      <nav class="nav-links" id="primaryNav" aria-label="Primary" aria-hidden="true">
+        <a href="/intake/">Intake</a>
+        <a href="/cms/">CMS</a>
+        <a href="/roadmap.html">Roadmap</a>
+        <a href="/calculators.html">Calculators</a>
+        <a href="/arecibo.html">Arecibo Line</a>
+        <a href="/articles.html">Articles</a>
+        <details>
+          <summary>About Nummerology</summary>
+          <div class="nav-dropdown">
+            <a href="/about.html">Our Story</a>
+            <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+            <a href="/about-academy.html">Academy &amp; AI</a>
+          </div>
+        </details>
+        <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+          <span aria-hidden="true">🌞</span>
+          Night mode
+        </button>
+      </nav>
     </header>
+    <div class="menu-overlay" id="menuOverlay" hidden></div>
     <main>
       <div class="layout">
         <section class="hero-card" aria-labelledby="welcome-title">
@@ -769,6 +861,59 @@
       const progressLabel = document.getElementById("progressLabel");
       const progressTrack = document.querySelector(".progress-track");
       const modeToggle = document.getElementById("modeToggle");
+      const menuToggleButton = document.getElementById("menuToggle");
+      const primaryNav = document.getElementById("primaryNav");
+      const menuOverlay = document.getElementById("menuOverlay");
+
+      const setMenuState = (open) => {
+        if (menuToggleButton) {
+          menuToggleButton.setAttribute("aria-expanded", String(open));
+        }
+        if (primaryNav) {
+          primaryNav.setAttribute("aria-hidden", String(!open));
+        }
+        if (menuOverlay) {
+          if (open) {
+            menuOverlay.removeAttribute("hidden");
+          } else {
+            menuOverlay.setAttribute("hidden", "");
+          }
+        }
+        document.body.classList.toggle("menu-open", open);
+      };
+
+      const closeMenu = () => {
+        setMenuState(false);
+        primaryNav?.querySelectorAll("details[open]").forEach((detail) => {
+          detail.removeAttribute("open");
+        });
+      };
+      const openMenu = () => setMenuState(true);
+
+      menuToggleButton?.addEventListener("click", () => {
+        const expanded = menuToggleButton.getAttribute("aria-expanded") === "true";
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      menuOverlay?.addEventListener("click", closeMenu);
+
+      primaryNav?.querySelectorAll("a").forEach((link) => {
+        link.addEventListener("click", closeMenu);
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          const expanded = menuToggleButton?.getAttribute("aria-expanded") === "true";
+          if (expanded) {
+            closeMenu();
+            menuToggleButton?.focus();
+          }
+        }
+      });
 
       const valueElements = {
         life_path: document.querySelector('[data-value="life_path"]'),
@@ -892,6 +1037,7 @@
       });
 
       modeToggle.addEventListener("click", () => {
+        closeMenu();
         const pressed = modeToggle.getAttribute("aria-pressed") === "true";
         modeToggle.setAttribute("aria-pressed", String(!pressed));
         document.body.classList.toggle("night", !pressed);
@@ -901,8 +1047,8 @@
       const nightStyles = document.createElement("style");
       nightStyles.textContent = `
         body.night {
-          background: #101322;
-          color: #f4f6ff;
+          background: #0e1713;
+          color: #e8f5ec;
         }
         body.night header,
         body.night main {
@@ -912,57 +1058,65 @@
         body.night .step-card,
         body.night .snapshot-card,
         body.night .stories-card {
-          background: #171b2b;
-          border-color: rgba(92, 105, 210, 0.25);
+          background: #13231b;
+          border-color: rgba(60, 177, 121, 0.25);
           box-shadow: none;
         }
         body.night .progress-footer {
-          background: rgba(16, 19, 34, 0.95);
-          border-top-color: rgba(92, 105, 210, 0.25);
+          background: rgba(10, 20, 15, 0.92);
+          border-top-color: rgba(60, 177, 121, 0.25);
         }
         body.night .progress-card {
-          background: #1f2336;
-          border-color: rgba(92, 105, 210, 0.35);
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.3);
           box-shadow: none;
         }
         body.night .progress-track {
-          background: rgba(92, 105, 210, 0.25);
+          background: rgba(60, 177, 121, 0.2);
         }
         body.night .progress-bar {
-          background: linear-gradient(135deg, #7f8cff, #55c3ff);
-          box-shadow: 0 10px 25px rgba(87, 132, 255, 0.35);
+          background: linear-gradient(135deg, #3cb179, #67f0aa);
+          box-shadow: 0 10px 25px rgba(60, 177, 121, 0.35);
         }
         body.night .snapshot-tile,
         body.night .story-tile {
-          background: rgba(127, 140, 255, 0.12);
-          border-color: rgba(92, 105, 210, 0.25);
+          background: rgba(60, 177, 121, 0.18);
+          border-color: rgba(60, 177, 121, 0.25);
         }
         body.night .pill {
-          background: rgba(127, 140, 255, 0.14);
-          color: rgba(244, 246, 255, 0.78);
-          border-color: rgba(127, 140, 255, 0.25);
+          background: rgba(60, 177, 121, 0.2);
+          color: rgba(232, 245, 236, 0.85);
+          border-color: rgba(60, 177, 121, 0.35);
+        }
+        body.night .nav-links {
+          background: #0f1d17;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: -24px 0 60px rgba(0, 0, 0, 0.55);
         }
         body.night .nav-links a,
         body.night .nav-links summary,
         body.night .mode-toggle {
-          color: rgba(244, 246, 255, 0.78);
+          color: rgba(232, 245, 236, 0.78);
         }
         body.night .nav-dropdown {
-          background: #1f2336;
-          border-color: rgba(92, 105, 210, 0.25);
-          box-shadow: 0 24px 44px rgba(8, 10, 18, 0.6);
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
         }
         body.night .nav-dropdown a:hover,
         body.night .nav-dropdown a:focus {
-          background: rgba(127, 140, 255, 0.18);
-          color: #f4f6ff;
+          background: rgba(60, 177, 121, 0.22);
+          color: #e8f5ec;
         }
         body.night .mode-toggle {
-          background: rgba(127, 140, 255, 0.12);
-          border-color: rgba(92, 105, 210, 0.25);
+          background: rgba(60, 177, 121, 0.16);
+          border-color: rgba(60, 177, 121, 0.3);
+        }
+        body.night .menu-overlay {
+          background: rgba(4, 12, 8, 0.7);
         }
         body.night footer {
-          color: rgba(244, 246, 255, 0.6);
+          color: rgba(232, 245, 236, 0.7);
         }
       `;
       document.head.appendChild(nightStyles);

--- a/roadmap.html
+++ b/roadmap.html
@@ -7,16 +7,16 @@
     <style>
       :root {
         color-scheme: light;
-        --page-bg: #fdf7f0;
+        --page-bg: #f0f8f3;
         --card-bg: #ffffff;
-        --card-elevated: #fffaf4;
-        --border: #f0dfcd;
-        --text: #2a2220;
-        --muted: #6f5b53;
-        --accent: #ff8a3d;
-        --accent-soft: rgba(255, 138, 61, 0.12);
-        --accent-strong: #f55d0d;
-        --shadow: 0px 30px 60px rgba(228, 187, 147, 0.35);
+        --card-elevated: #f7fcf8;
+        --border: #c8e5d2;
+        --text: #1f3327;
+        --muted: #4f6b59;
+        --accent: #3cb179;
+        --accent-soft: rgba(60, 177, 121, 0.12);
+        --accent-strong: #2d8f60;
+        --shadow: 0px 30px 60px rgba(92, 170, 120, 0.28);
         font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
       }
 
@@ -27,8 +27,8 @@
       body {
         margin: 0;
         min-height: 100vh;
-        background: radial-gradient(circle at top right, rgba(255, 204, 153, 0.35), transparent 60%),
-          radial-gradient(circle at bottom left, rgba(255, 165, 102, 0.25), transparent 55%), var(--page-bg);
+        background: radial-gradient(circle at top right, rgba(94, 214, 149, 0.32), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(72, 176, 120, 0.2), transparent 55%), var(--page-bg);
         color: var(--text);
         display: flex;
         flex-direction: column;
@@ -70,11 +70,93 @@
         font-weight: 700;
       }
 
-      .nav-links {
-        display: flex;
+      .menu-toggle {
+        border: none;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        display: inline-flex;
         align-items: center;
-        gap: 1.25rem;
+        gap: 0.65rem;
         font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, background 0.2s ease;
+      }
+
+      .menu-toggle:hover,
+      .menu-toggle:focus-visible {
+        transform: translateY(-1px);
+        background: var(--accent-strong);
+        outline: none;
+      }
+
+      .menu-icon {
+        position: relative;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: background 0.2s ease;
+      }
+
+      .menu-icon::before,
+      .menu-icon::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        border-radius: 999px;
+        transition: transform 0.2s ease;
+      }
+
+      .menu-icon::before {
+        top: -6px;
+      }
+
+      .menu-icon::after {
+        top: 6px;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon {
+        background: transparent;
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::before {
+        transform: translateY(6px) rotate(45deg);
+      }
+
+      .menu-toggle[aria-expanded="true"] .menu-icon::after {
+        transform: translateY(-6px) rotate(-45deg);
+      }
+
+      .menu-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .nav-links {
+        position: fixed;
+        inset: 0 0 0 auto;
+        width: min(320px, 85vw);
+        background: var(--card-bg);
+        border-left: 1px solid var(--border);
+        box-shadow: -24px 0 60px rgba(17, 37, 23, 0.18);
+        padding: 6rem 1.75rem 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 20;
+      }
+
+      body.menu-open .nav-links {
+        transform: translateX(0);
       }
 
       .nav-links a,
@@ -82,10 +164,13 @@
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        display: inline-flex;
+        display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: 0.35rem;
-        transition: color 0.2s ease;
+        padding: 0.75rem 1rem;
+        border-radius: 14px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-links summary {
@@ -97,18 +182,18 @@
         display: none;
       }
 
+      .nav-links details {
+        width: 100%;
+      }
+
       .nav-links summary::after {
         content: "▾";
-        font-size: 0.65rem;
+        font-size: 0.75rem;
         transition: transform 0.2s ease;
       }
 
-      .nav-links details {
-        position: relative;
-      }
-
       .nav-links details[open] > summary {
-        color: var(--text);
+        color: var(--accent-strong);
       }
 
       .nav-links details[open] > summary::after {
@@ -116,30 +201,27 @@
       }
 
       .nav-dropdown {
-        position: absolute;
-        top: calc(100% + 0.75rem);
-        left: 0;
-        min-width: 14rem;
+        margin-top: 0.35rem;
         background: var(--card-bg);
         border: 1px solid var(--border);
-        border-radius: 16px;
-        padding: 0.75rem;
+        border-radius: 14px;
+        padding: 0.5rem;
         display: grid;
         gap: 0.35rem;
-        box-shadow: var(--shadow);
-        z-index: 10;
+        box-shadow: none;
       }
 
       .nav-dropdown a {
         font-weight: 600;
         color: var(--muted);
-        padding: 0.35rem 0.5rem;
+        padding: 0.45rem 0.75rem;
         border-radius: 10px;
+        transition: background 0.2s ease, color 0.2s ease;
       }
 
       .nav-dropdown a:hover,
-      .nav-dropdown a:focus {
-        color: var(--text);
+      .nav-dropdown a:focus-visible {
+        color: var(--accent-strong);
         background: var(--accent-soft);
         outline: none;
       }
@@ -150,21 +232,44 @@
       }
 
       .mode-toggle {
-        border: 1px solid rgba(0, 0, 0, 0.05);
+        border: 1px solid rgba(60, 177, 121, 0.3);
         background: #fff;
         border-radius: 999px;
-        padding: 0.45rem 1.1rem;
+        padding: 0.6rem 1.1rem;
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
         color: var(--muted);
         font-weight: 600;
         cursor: pointer;
-        transition: transform 0.2s ease;
+        transition: transform 0.2s ease, background 0.2s ease;
+        justify-content: center;
       }
 
-      .mode-toggle:hover {
+      .mode-toggle:hover,
+      .mode-toggle:focus-visible {
         transform: translateY(-1px);
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .menu-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 35, 23, 0.4);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 10;
+      }
+
+      body.menu-open .menu-overlay {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      body.menu-open {
+        overflow: hidden;
       }
 
       main {
@@ -197,7 +302,7 @@
       }
 
       .card {
-        background: linear-gradient(150deg, rgba(255, 243, 227, 0.9), rgba(255, 255, 255, 0.95));
+        background: linear-gradient(150deg, rgba(214, 244, 227, 0.9), rgba(255, 255, 255, 0.95));
         border-radius: 32px;
         padding: clamp(1.75rem, 3vw, 2.5rem);
         box-shadow: var(--shadow);
@@ -272,28 +377,33 @@
           <small>ÅSE STEINSLAND</small>
           <strong>Numerologist Studio</strong>
         </a>
-        <nav class="nav-links" aria-label="Primary">
-          <a href="/intake/">Intake</a>
-          <a href="/cms/">CMS</a>
-          <a href="/roadmap.html" aria-current="page">Roadmap</a>
-          <a href="/calculators.html">Calculators</a>
-          <a href="/arecibo.html">Arecibo Line</a>
-          <a href="/articles.html">Articles</a>
-          <details>
-            <summary>About Nummerology</summary>
-            <div class="nav-dropdown">
-              <a href="/about.html">Our Story</a>
-              <a href="/about-vision-mission.html">Vision &amp; Mission</a>
-              <a href="/about-academy.html">Academy &amp; AI</a>
-            </div>
-          </details>
-          <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
-            <span aria-hidden="true">🌞</span>
-            Night mode
-          </button>
-        </nav>
+        <button class="menu-toggle" type="button" id="menuToggle" aria-expanded="false" aria-controls="primaryNav">
+          <span class="menu-icon" aria-hidden="true"></span>
+          <span class="menu-label">Menu</span>
+        </button>
       </div>
+      <nav class="nav-links" id="primaryNav" aria-label="Primary" aria-hidden="true">
+        <a href="/intake/">Intake</a>
+        <a href="/cms/">CMS</a>
+        <a href="/roadmap.html">Roadmap</a>
+        <a href="/calculators.html">Calculators</a>
+        <a href="/arecibo.html">Arecibo Line</a>
+        <a href="/articles.html">Articles</a>
+        <details>
+          <summary>About Nummerology</summary>
+          <div class="nav-dropdown">
+            <a href="/about.html">Our Story</a>
+            <a href="/about-vision-mission.html">Vision &amp; Mission</a>
+            <a href="/about-academy.html">Academy &amp; AI</a>
+          </div>
+        </details>
+        <button class="mode-toggle" type="button" id="modeToggle" aria-pressed="false">
+          <span aria-hidden="true">🌞</span>
+          Night mode
+        </button>
+      </nav>
     </header>
+    <div class="menu-overlay" id="menuOverlay" hidden></div>
     <main>
       <div class="layout">
         <section class="card" aria-labelledby="roadmap-title">
@@ -363,6 +473,61 @@
     <footer>© <span id="year"></span> Numerologist Studio. Guided by Åse Steinsland.</footer>
     <script>
       const modeToggle = document.getElementById("modeToggle");
+      const menuToggleButton = document.getElementById("menuToggle");
+      const primaryNav = document.getElementById("primaryNav");
+      const menuOverlay = document.getElementById("menuOverlay");
+
+      const setMenuState = (open) => {
+        if (menuToggleButton) {
+          menuToggleButton.setAttribute("aria-expanded", String(open));
+        }
+        if (primaryNav) {
+          primaryNav.setAttribute("aria-hidden", String(!open));
+        }
+        if (menuOverlay) {
+          if (open) {
+            menuOverlay.removeAttribute("hidden");
+          } else {
+            menuOverlay.setAttribute("hidden", "");
+          }
+        }
+        document.body.classList.toggle("menu-open", open);
+      };
+
+      const closeMenu = () => {
+        setMenuState(false);
+        primaryNav?.querySelectorAll("details[open]").forEach((detail) => {
+          detail.removeAttribute("open");
+        });
+      };
+      const openMenu = () => setMenuState(true);
+
+      menuToggleButton?.addEventListener("click", () => {
+        const expanded = menuToggleButton.getAttribute("aria-expanded") === "true";
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      menuOverlay?.addEventListener("click", closeMenu);
+
+      primaryNav?.querySelectorAll("a").forEach((link) => {
+        link.addEventListener("click", closeMenu);
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          const expanded = menuToggleButton?.getAttribute("aria-expanded") === "true";
+          if (expanded) {
+            closeMenu();
+            menuToggleButton?.focus();
+          }
+        }
+      });
+
+
       const setMode = (night) => {
         document.body.classList.toggle("night", night);
         modeToggle.setAttribute("aria-pressed", night ? "true" : "false");
@@ -373,6 +538,7 @@
       };
 
       modeToggle.addEventListener("click", () => {
+        closeMenu();
         setMode(!document.body.classList.contains("night"));
       });
 
@@ -386,35 +552,76 @@
       const nightStyles = document.createElement("style");
       nightStyles.textContent = `
         body.night {
-          background: radial-gradient(circle at top right, rgba(69, 48, 107, 0.45), transparent 60%),
-            radial-gradient(circle at bottom left, rgba(255, 138, 61, 0.15), transparent 55%), #1f1b2a;
-          color: #f6f2ff;
+          background: #0e1713;
+          color: #e8f5ec;
         }
-        body.night .card {
-          background: linear-gradient(150deg, rgba(53, 39, 79, 0.85), rgba(30, 25, 42, 0.95));
+        body.night header,
+        body.night main {
+          background: transparent;
         }
-        body.night .phase {
-          background: rgba(33, 28, 46, 0.92);
-          border-color: rgba(115, 90, 168, 0.4);
+        body.night .hero-card,
+        body.night .step-card,
+        body.night .snapshot-card,
+        body.night .stories-card {
+          background: #13231b;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
+        }
+        body.night .progress-footer {
+          background: rgba(10, 20, 15, 0.92);
+          border-top-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .progress-card {
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.3);
+          box-shadow: none;
+        }
+        body.night .progress-track {
+          background: rgba(60, 177, 121, 0.2);
+        }
+        body.night .progress-bar {
+          background: linear-gradient(135deg, #3cb179, #67f0aa);
+          box-shadow: 0 10px 25px rgba(60, 177, 121, 0.35);
+        }
+        body.night .snapshot-tile,
+        body.night .story-tile {
+          background: rgba(60, 177, 121, 0.18);
+          border-color: rgba(60, 177, 121, 0.25);
+        }
+        body.night .pill {
+          background: rgba(60, 177, 121, 0.2);
+          color: rgba(232, 245, 236, 0.85);
+          border-color: rgba(60, 177, 121, 0.35);
+        }
+        body.night .nav-links {
+          background: #0f1d17;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: -24px 0 60px rgba(0, 0, 0, 0.55);
         }
         body.night .nav-links a,
         body.night .nav-links summary,
         body.night .mode-toggle {
-          color: rgba(246, 242, 255, 0.75);
+          color: rgba(232, 245, 236, 0.78);
         }
         body.night .nav-dropdown {
-          background: rgba(30, 25, 42, 0.95);
-          border-color: rgba(115, 90, 168, 0.4);
-          box-shadow: 0px 30px 60px rgba(22, 16, 38, 0.6);
+          background: #16291f;
+          border-color: rgba(60, 177, 121, 0.25);
+          box-shadow: none;
         }
         body.night .nav-dropdown a:hover,
         body.night .nav-dropdown a:focus {
-          background: rgba(255, 138, 61, 0.2);
-          color: #f6f2ff;
+          background: rgba(60, 177, 121, 0.22);
+          color: #e8f5ec;
         }
         body.night .mode-toggle {
-          background: rgba(246, 242, 255, 0.08);
-          border-color: rgba(115, 90, 168, 0.3);
+          background: rgba(60, 177, 121, 0.16);
+          border-color: rgba(60, 177, 121, 0.3);
+        }
+        body.night .menu-overlay {
+          background: rgba(4, 12, 8, 0.7);
+        }
+        body.night footer {
+          color: rgba(232, 245, 236, 0.7);
         }
       `;
       document.head.appendChild(nightStyles);


### PR DESCRIPTION
## Summary
- restyle the public pages with a fresh green palette and gradients
- convert the top navigation into a burger drawer with overlay support across pages
- wire up shared menu/dark-mode scripts, including calculators and the Arecibo line calculator

## Testing
- `python -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_68fd28ebbd888323ac3b7771a847337b