### PR TITLE
Gracefully handle optional article analysis hook

### DIFF
--- a/articles/tests/test_views.py
+++ b/articles/tests/test_views.py
@@ -1,0 +1,36 @@
+"""Tests for the article views module."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from articles import views
+
+
+class LoadAIAnalysisHookTests(SimpleTestCase):
+    def test_returns_none_when_module_missing(self) -> None:
+        """If the optional module is absent the hook should be ``None``."""
+
+        with mock.patch("articles.views.find_spec", return_value=None):
+            self.assertIsNone(views._load_ai_analysis_hook())
+
+    def test_returns_callable_when_module_available(self) -> None:
+        """When the module exists, the callable from the module is returned."""
+
+        fake_callable = object()
+        with mock.patch("articles.views.find_spec", return_value=object()), mock.patch(
+            "articles.views.import_module",
+            return_value=SimpleNamespace(ai_analyze_content=fake_callable),
+        ):
+            self.assertIs(views._load_ai_analysis_hook(), fake_callable)
+
+    def test_returns_none_when_import_raises(self) -> None:
+        """Import errors should not bubble up from the optional hook loader."""
+
+        with mock.patch("articles.views.find_spec", return_value=object()), mock.patch(
+            "articles.views.import_module", side_effect=ImportError
+        ):
+            self.assertIsNone(views._load_ai_analysis_hook())

--- a/articles/views.py
+++ b/articles/views.py
@@ -13,7 +13,10 @@ def _load_ai_analysis_hook() -> Optional[Callable[[str], str]]:
     module_name = "some_module"
     if find_spec(module_name) is None:
         return None
-    module = import_module(module_name)
+    try:
+        module = import_module(module_name)
+    except ImportError:
+        return None
     return getattr(module, "ai_analyze_content", None)
 
 


### PR DESCRIPTION
## Summary
- guard the optional article AI analysis hook against ImportError so the list view remains stable
- add unit tests covering the hook loader behaviour for missing modules, successful imports, and import errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fe946d99648323b40d304006810c46