### PR TITLE
Fix intake navigation reverse errors

### DIFF
--- a/intake/urls.py
+++ b/intake/urls.py
@@ -6,4 +6,5 @@ app_name = "intake"
 
 urlpatterns = [
     path("", intake_view, name="form"),
+    path("", intake_view, name="index"),
 ]

--- a/tall_project/urls.py
+++ b/tall_project/urls.py
@@ -22,5 +22,6 @@ urlpatterns = [
     path("articles/", include("articles.urls")),
     path("healthz/", health_check, name="health_check"),
     path("", home, name="home"),
+    path("", home, name="index"),
     path("<slug:slug>/", static_page, name="static_page"),
 ]


### PR DESCRIPTION
## Summary
- add an `index` alias for the home route so legacy reverse lookups succeed
- add an `index` alias within the intake namespace to satisfy navigation links

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ff65dc4ae48323b99b04197214b802