### PR TITLE
Convert Numerologist to shared-hosting PHP pages

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,11 @@
+DirectoryIndex index.php
+
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteCond %{REQUEST_FILENAME} -f [OR]
+  RewriteCond %{REQUEST_FILENAME} -d
+  RewriteRule ^ - [L]
+
+  RewriteRule ^sider/([a-z0-9-]+)/?$ page.php?slug=$1 [L,QSA]
+  RewriteRule ^tall/(\d+)/?$ number.php?number=$1 [L,QSA]
+</IfModule>

--- a/README.md
+++ b/README.md
@@ -1,73 +1,31 @@
-# Numerologist 🔢✨
+# Numerologist (PHP-utgave)
 
-Numerologist is an AI-driven web platform for **numerology analysis**, **character profiling**, and **life-path forecasting** — blending data science with spiritual symbolism.
+Denne versjonen er gjort om til **rene PHP-sider** slik at du kan laste opp prosjektet på et vanlig webhotell (ikke VPS), uten å installere Python, Django eller andre tjenester på serveren.
 
-It is developed and maintained by [Arshian Visionary & Intelligence](https://biiaab.ir) as part of the "Setaei Intelligence" ecosystem.
+## Hva som trengs på serveren
+- PHP 8.x (typisk allerede aktivert hos webhotell)
+- Apache/Nginx med vanlig PHP-støtte
+- FTP/SFTP for opplasting
 
----
+## Struktur
+- `index.php` — forside + numerologi-kalkulator
+- `page.php` — statiske infosider via `?slug=`
+- `number.php` — enkel tolkning av tall via `?number=`
+- `includes/data.php` — logikk og sideinnhold
+- `includes/layout.php` — header/footer
+- `assets/style.css` — stilark
+- `.htaccess` — valgfri rewrite for penere URL-er
 
-## 🚀 Features
-- Dynamic numerology calculations (Pythagorean & Chaldean)
-- Personality mapping (1–9 archetypes + master numbers)
-- AI-based text interpretation of results
-- Birthdate → Life Path visual charts
-- Name Analyzer (vowel/consonant balance)
-- Localization support (English / Norwegian / Persian)
-- API ready for integrations with other Arshian projects
-
----
-
-## 🧩 Tech Stack
-| Layer | Technology |
-|-------|-------------|
-| Frontend | Python Flask / FastAPI (planned React UI) |
-| Backend | Django (REST API) |
-| Database | PostgreSQL / SQLite (dev) |
-| Hosting | Codex + FTP Deployment (numerologist.setaei.com) |
-| Version Control | GitHub |
-| Dev Tools | Figma, VSCode, Docker (future), GitHub Actions |
-
----
-
-## 🌍 Deployment
-Current live subdomain:
-> https://numerologist.setaei.com
-
----
-
-## 🧪 Status
-🟢 **MVP Phase** — Core numerology engine and UI under development.  
-🧭 **Next:** Integrate dynamic charts and AI explanations (OpenAI API / local LLM).
-
----
-
-## 📖 Documentation
-- [Setup Guide](docs/Setup_Guide.md)
-- [Numerology Engine](docs/Numerology_Engine.md)
-- [API Reference](docs/API_Reference.md)
-- [Architecture Overview](docs/Architecture_Overview.md)
-- [Contributors & Credits](docs/Contributors_and_Credits.md)
-
----
-
-# 🛠️ Setup Guide
-
-## Requirements
-- Python 3.11+
-- pip / virtualenv
-- Git
-
-## Installation
+## Lokal test
 ```bash
-git clone https://github.com/XS227/Numerologist.git
-cd Numerologist
-python -m venv venv
-source venv/bin/activate  # or venv\Scripts\activate on Windows
-pip install -r requirements.txt
+php -S 127.0.0.1:8080
 ```
+Åpne deretter `http://127.0.0.1:8080`.
 
-If you see `ModuleNotFoundError: No module named 'django'` when running management
-commands, double-check that the dependency installation finished successfully.
-Corporate or sandboxed environments may block outbound PyPI traffic; in that
-case download the wheels from a networked machine and install them via
-`pip install --no-index --find-links <wheel-directory> -r requirements.txt`.
+## Opplasting til webhotell
+1. Last opp alle filene i prosjektroten til `public_html` (eller tilsvarende).
+2. Pass på at `index.php` ligger i webroot.
+3. Besøk domenet ditt — siden skal fungere uten ekstra installasjon.
+
+## Notat
+Denne varianten er bevisst enkel og driftssikker for delt hosting.

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,7 @@
+:root{--bg:#f0f8f3;--card:#fff;--text:#1f3327;--accent:#2d8f60;--line:#c8e5d2}
+*{box-sizing:border-box}body{margin:0;font-family:Arial,sans-serif;background:var(--bg);color:var(--text)}
+.wrap{max-width:920px;margin:0 auto;padding:0 16px}header{background:#fff;border-bottom:1px solid var(--line)}
+header .wrap{display:flex;justify-content:space-between;align-items:center;padding:14px 16px}nav a,.brand{margin-right:12px;color:var(--accent);text-decoration:none;font-weight:700}
+main{padding:24px 0;display:grid;gap:16px}.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:16px}
+.form-grid{display:grid;gap:10px}input,button{padding:10px;border:1px solid var(--line);border-radius:10px}button{background:var(--accent);color:#fff;border:none;cursor:pointer}
+.result-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:10px;margin-top:12px}.error{color:#a30000}footer{padding:20px 0;color:#4f6b59}

--- a/includes/data.php
+++ b/includes/data.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+function digit_sum(int $number): int
+{
+    return array_sum(array_map('intval', str_split((string) $number)));
+}
+
+function reduce_number(int $number): int
+{
+    $masters = [11, 22, 33];
+    while ($number > 9 && !in_array($number, $masters, true)) {
+        $number = digit_sum($number);
+    }
+
+    return $number;
+}
+
+function letter_value(string $letter): int
+{
+    static $map = [
+        'A' => 1, 'J' => 1, 'S' => 1,
+        'B' => 2, 'K' => 2, 'T' => 2,
+        'C' => 3, 'L' => 3, 'U' => 3,
+        'D' => 4, 'M' => 4, 'V' => 4,
+        'E' => 5, 'N' => 5, 'W' => 5,
+        'F' => 6, 'O' => 6, 'X' => 6,
+        'G' => 7, 'P' => 7, 'Y' => 7,
+        'H' => 8, 'Q' => 8, 'Z' => 8,
+        'I' => 9, 'R' => 9,
+        'Å' => 1, 'Æ' => 5, 'Ø' => 6,
+    ];
+
+    return $map[$letter] ?? 0;
+}
+
+function reduce_name(string $name, ?array $filterLetters = null): int
+{
+    $sum = 0;
+    $letters = preg_split('//u', mb_strtoupper($name), -1, PREG_SPLIT_NO_EMPTY);
+
+    foreach ($letters as $letter) {
+        if (!preg_match('/\p{L}/u', $letter)) {
+            continue;
+        }
+        if ($filterLetters !== null && !in_array($letter, $filterLetters, true)) {
+            continue;
+        }
+        $sum += letter_value($letter);
+    }
+
+    return reduce_number($sum);
+}
+
+function calculate_numerology(string $fullName, string $birthDate): array
+{
+    $dateDigits = preg_replace('/\D/', '', $birthDate) ?? '';
+    $lifePath = reduce_number((int) $dateDigits);
+
+    $vowels = ['A', 'E', 'I', 'O', 'U', 'Y', 'Æ', 'Ø', 'Å'];
+    $allLetters = array_keys([
+        'A'=>1,'B'=>1,'C'=>1,'D'=>1,'E'=>1,'F'=>1,'G'=>1,'H'=>1,'I'=>1,'J'=>1,
+        'K'=>1,'L'=>1,'M'=>1,'N'=>1,'O'=>1,'P'=>1,'Q'=>1,'R'=>1,'S'=>1,'T'=>1,
+        'U'=>1,'V'=>1,'W'=>1,'X'=>1,'Y'=>1,'Z'=>1,'Æ'=>1,'Ø'=>1,'Å'=>1,
+    ]);
+    $consonants = array_values(array_diff($allLetters, $vowels));
+
+    return [
+        'life_path' => $lifePath,
+        'expression' => reduce_name($fullName),
+        'soul_urge' => reduce_name($fullName, $vowels),
+        'personality' => reduce_name($fullName, $consonants),
+    ];
+}
+
+$pages = [
+    'discover-numerology' => [
+        'title' => 'Discover Numerology',
+        'body' => 'Utforsk grunnprinsippene i numerologi og hvordan tall brukes til å forstå personlighet, livssyklus og potensial.',
+    ],
+    'calculators' => [
+        'title' => 'Calculator Suite',
+        'body' => 'Samling av enkle kalkulatorer for livsvei, uttrykkstall og navn-analyse direkte i nettleseren.',
+    ],
+    'resources' => [
+        'title' => 'Resources',
+        'body' => 'Ressursside med artikler, referanser og anbefalt lesing for videre fordypning.',
+    ],
+    'guidance-support' => [
+        'title' => 'Guidance & Support',
+        'body' => 'Informasjon om veiledning, spørsmål/svar og kontaktmuligheter.',
+    ],
+    'legal' => [
+        'title' => 'Legal',
+        'body' => 'Personvern, vilkår og juridisk informasjon for nettstedet.',
+    ],
+];
+
+$numberInterpretations = [
+    1 => ['title' => 'Number 1', 'essence' => 'Lederskap, initiativ og selvstendighet.'],
+    2 => ['title' => 'Number 2', 'essence' => 'Samarbeid, balanse og relasjoner.'],
+    3 => ['title' => 'Number 3', 'essence' => 'Kreativitet, kommunikasjon og glede.'],
+    4 => ['title' => 'Number 4', 'essence' => 'Struktur, disiplin og stabilitet.'],
+    5 => ['title' => 'Number 5', 'essence' => 'Frihet, endring og eventyr.'],
+    6 => ['title' => 'Number 6', 'essence' => 'Omsorg, ansvar og harmoni.'],
+    7 => ['title' => 'Number 7', 'essence' => 'Analyse, intuisjon og indre søken.'],
+    8 => ['title' => 'Number 8', 'essence' => 'Makt, resultater og materiell mestring.'],
+    9 => ['title' => 'Number 9', 'essence' => 'Medfølelse, fullføring og visdom.'],
+    11 => ['title' => 'Master 11', 'essence' => 'Inspirasjon, intuisjon og oppvåkning.'],
+    22 => ['title' => 'Master 22', 'essence' => 'Visjon, bygging og kollektivt bidrag.'],
+    33 => ['title' => 'Master 33', 'essence' => 'Healing, undervisning og tjeneste.'],
+];

--- a/includes/layout.php
+++ b/includes/layout.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+function render_header(string $title): void
+{
+    echo '<!doctype html><html lang="no"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">';
+    echo '<title>' . htmlspecialchars($title) . ' | Numerologist</title>';
+    echo '<link rel="stylesheet" href="/assets/style.css">';
+    echo '</head><body><header><div class="wrap"><a class="brand" href="/index.php">Numerologist</a><nav>';
+    echo '<a href="/index.php">Hjem</a><a href="/page.php?slug=discover-numerology">Numerologi</a><a href="/page.php?slug=resources">Ressurser</a><a href="/page.php?slug=legal">Legal</a>';
+    echo '</nav></div></header><main class="wrap">';
+}
+
+function render_footer(): void
+{
+    echo '</main><footer><div class="wrap">Klar for delt hosting (kun PHP-filer)</div></footer></body></html>';
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/includes/data.php';
+require __DIR__ . '/includes/layout.php';
+
+$result = null;
+$error = null;
+$fullName = '';
+$birthDate = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $fullName = trim((string) ($_POST['full_name'] ?? ''));
+    $birthDate = (string) ($_POST['birth_date'] ?? '');
+
+    if ($fullName === '' || $birthDate === '') {
+        $error = 'Fyll inn navn og fødselsdato.';
+    } else {
+        $result = calculate_numerology($fullName, $birthDate);
+    }
+}
+
+render_header('Hjem');
+?>
+<section class="card">
+  <h1>Numerologist i ren PHP</h1>
+  <p>Dette er en serverløs versjon (ingen Python/Django installasjon). Last opp filene via FTP på vanlig webhotell med PHP-støtte.</p>
+</section>
+
+<section class="card">
+  <h2>Rask kalkulator</h2>
+  <?php if ($error !== null): ?>
+    <p class="error"><?= htmlspecialchars($error) ?></p>
+  <?php endif; ?>
+  <form method="post" class="form-grid">
+    <label>
+      Fullt navn
+      <input type="text" name="full_name" value="<?= htmlspecialchars($fullName) ?>" required>
+    </label>
+    <label>
+      Fødselsdato
+      <input type="date" name="birth_date" value="<?= htmlspecialchars($birthDate) ?>" required>
+    </label>
+    <button type="submit">Beregn</button>
+  </form>
+
+  <?php if ($result !== null): ?>
+    <div class="result-grid">
+      <article><h3>Livsvei</h3><p><a href="/number.php?number=<?= $result['life_path'] ?>"><?= $result['life_path'] ?></a></p></article>
+      <article><h3>Uttrykkstall</h3><p><?= $result['expression'] ?></p></article>
+      <article><h3>Sjelstallet</h3><p><?= $result['soul_urge'] ?></p></article>
+      <article><h3>Personlighet</h3><p><?= $result['personality'] ?></p></article>
+    </div>
+  <?php endif; ?>
+</section>
+
+<section class="card">
+  <h2>Sider</h2>
+  <ul>
+    <?php foreach ($pages as $slug => $page): ?>
+      <li><a href="/page.php?slug=<?= urlencode($slug) ?>"><?= htmlspecialchars($page['title']) ?></a></li>
+    <?php endforeach; ?>
+  </ul>
+</section>
+<?php render_footer(); ?>

--- a/number.php
+++ b/number.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/includes/data.php';
+require __DIR__ . '/includes/layout.php';
+
+$number = (int) ($_GET['number'] ?? 0);
+$profile = $numberInterpretations[$number] ?? null;
+
+if ($profile === null) {
+    http_response_code(404);
+    render_header('Tall ikke funnet');
+    echo '<section class="card"><h1>404</h1><p>Dette tallet har ingen profil.</p></section>';
+    render_footer();
+    exit;
+}
+
+render_header($profile['title']);
+?>
+<section class="card">
+  <h1><?= htmlspecialchars($profile['title']) ?></h1>
+  <p><?= htmlspecialchars($profile['essence']) ?></p>
+</section>
+<?php render_footer(); ?>

--- a/page.php
+++ b/page.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/includes/data.php';
+require __DIR__ . '/includes/layout.php';
+
+$slug = (string) ($_GET['slug'] ?? '');
+$page = $pages[$slug] ?? null;
+
+if ($page === null) {
+    http_response_code(404);
+    render_header('Fant ikke siden');
+    echo '<section class="card"><h1>404</h1><p>Siden finnes ikke.</p></section>';
+    render_footer();
+    exit;
+}
+
+render_header($page['title']);
+?>
+<section class="card">
+  <h1><?= htmlspecialchars($page['title']) ?></h1>
+  <p><?= htmlspecialchars($page['body']) ?></p>
+</section>
+<?php render_footer(); ?>


### PR DESCRIPTION
### Motivation
- Make the site runnable on standard shared hosting without installing Python, Django or other server-side packages.
- Provide a lightweight, FTP-uploadable front-end plus basic numerology calculator so the project can be deployed on non‑VPS webhosts.

### Description
- Replaced the Django-focused entrypoint with a pure PHP site and added `index.php` as the homepage and calculator front-end.
- Added `page.php` and `number.php` for static pages and number profile views, plus `includes/data.php` for numerology logic and `includes/layout.php` for header/footer.
- Added `assets/style.css` for basic styling and a `.htaccess` with `DirectoryIndex` and rewrite rules to enable prettier URLs on Apache hosts.
- Updated `README.md` with instructions for local testing via `php -S` and deployment to shared hosting.

### Testing
- Ran PHP syntax checks using `php -l` on `index.php`, `page.php`, `number.php`, `includes/data.php`, and `includes/layout.php`, and all lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a974472083238421e0a415fd40fb)